### PR TITLE
Authorize included resources

### DIFF
--- a/lib/jsonapi/authorization/authorizing_operations_processor.rb
+++ b/lib/jsonapi/authorization/authorizing_operations_processor.rb
@@ -30,11 +30,14 @@ module JSONAPI
 
       def authorize_include_directive
         return if @result.is_a?(::JSONAPI::ErrorsOperationResult)
-        resources = if @result.respond_to?(:resources)
-                      @result.resources
-                    else
-                      [@result.resource]
-                    end
+        resources = Array.wrap(
+          if @result.respond_to?(:resources)
+            @result.resources
+          elsif @result.respond_to?(:resource)
+            @result.resource
+          end
+        )
+
         resources.each do |resource|
           authorize_model_includes(resource._model)
         end

--- a/lib/jsonapi/authorization/authorizing_operations_processor.rb
+++ b/lib/jsonapi/authorization/authorizing_operations_processor.rb
@@ -260,6 +260,7 @@ module JSONAPI
       def authorize_include_item(resource_klass, source_record, include_item)
         case include_item
         when Hash
+          # e.g. {articles: [:comments, :author]} when ?include=articles.comments,articles.author
           include_item.each do |rel_name, deep|
             authorize_include_item(resource_klass, source_record, rel_name)
             relationship = resource_klass._relationship(rel_name)

--- a/lib/jsonapi/authorization/authorizing_operations_processor.rb
+++ b/lib/jsonapi/authorization/authorizing_operations_processor.rb
@@ -284,7 +284,7 @@ module JSONAPI
             related_record = source_record.public_send(
               relationship.relation_name(@operation.options[:context])
             )
-            authorizer.include_has_one_resource(related_record)
+            authorizer.include_has_one_resource(related_record) unless related_record.nil?
           when JSONAPI::Relationship::ToMany
             authorizer.include_has_many_resource(relationship.resource_klass._model_class)
           else

--- a/lib/jsonapi/authorization/authorizing_operations_processor.rb
+++ b/lib/jsonapi/authorization/authorizing_operations_processor.rb
@@ -264,17 +264,17 @@ module JSONAPI
           include_item.each do |rel_name, deep|
             authorize_include_item(resource_klass, source_record, rel_name)
             relationship = resource_klass._relationship(rel_name)
-            new_resource_klass = relationship.resource_klass
+            next_resource_klass = relationship.resource_klass
             Array.wrap(
               source_record.public_send(
                 relationship.relation_name(@operation.options[:context])
               )
-            ).each do |new_source_record|
-              deep.each do |new_include_item|
+            ).each do |next_source_record|
+              deep.each do |next_include_item|
                 authorize_include_item(
-                  new_resource_klass,
-                  new_source_record,
-                  new_include_item
+                  next_resource_klass,
+                  next_source_record,
+                  next_include_item
                 )
               end
             end

--- a/lib/jsonapi/authorization/authorizing_operations_processor.rb
+++ b/lib/jsonapi/authorization/authorizing_operations_processor.rb
@@ -97,6 +97,7 @@ module JSONAPI
         )._model
 
         authorizer.replace_fields(source_record, related_models)
+        authorize_model_includes(source_record)
       end
 
       def authorize_create_resource
@@ -242,8 +243,8 @@ module JSONAPI
       end
 
       def authorize_model_includes(source_record)
-        if @operation.include_directives
-          @operation.include_directives.model_includes.each do |include_item|
+        if @request.include_directives
+          @request.include_directives.model_includes.each do |include_item|
             authorize_include_item(@operation.resource_klass, source_record, include_item)
           end
         end

--- a/lib/jsonapi/authorization/authorizing_operations_processor.rb
+++ b/lib/jsonapi/authorization/authorizing_operations_processor.rb
@@ -88,6 +88,7 @@ module JSONAPI
         )._model
 
         authorizer.show_related_resources(source_record)
+        authorize_model_includes(source_record)
       end
 
       def authorize_replace_fields

--- a/lib/jsonapi/authorization/authorizing_operations_processor.rb
+++ b/lib/jsonapi/authorization/authorizing_operations_processor.rb
@@ -285,9 +285,13 @@ module JSONAPI
             related_record = source_record.public_send(
               relationship.relation_name(@operation.options[:context])
             )
-            authorizer.include_has_one_resource(related_record) unless related_record.nil?
+            return if related_record.nil?
+            authorizer.include_has_one_resource(related_record, source_record)
           when JSONAPI::Relationship::ToMany
-            authorizer.include_has_many_resource(relationship.resource_klass._model_class)
+            authorizer.include_has_many_resource(
+              relationship.resource_klass._model_class,
+              source_record
+            )
           else
             raise "Unexpected relationship type: #{relationship.inspect}"
           end

--- a/lib/jsonapi/authorization/authorizing_operations_processor.rb
+++ b/lib/jsonapi/authorization/authorizing_operations_processor.rb
@@ -79,6 +79,7 @@ module JSONAPI
         source_record = source_resource._model
         related_record = related_resource._model unless related_resource.nil?
         authorizer.show_related_resource(source_record, related_record)
+        authorize_model_includes(source_record)
       end
 
       def authorize_show_related_resources

--- a/lib/jsonapi/authorization/authorizing_operations_processor.rb
+++ b/lib/jsonapi/authorization/authorizing_operations_processor.rb
@@ -29,6 +29,7 @@ module JSONAPI
       end
 
       def authorize_include_directive
+        return if @result.is_a?(::JSONAPI::ErrorsOperationResult)
         resources = if @result.respond_to?(:resources)
                       @result.resources
                     else

--- a/lib/jsonapi/authorization/authorizing_operations_processor.rb
+++ b/lib/jsonapi/authorization/authorizing_operations_processor.rb
@@ -19,6 +19,26 @@ module JSONAPI
 
       def authorize_find
         authorizer.find(@operation.resource_klass._model_class)
+        if @operation.include_directives
+          @operation.include_directives.model_includes.each do |include_item|
+            case include_item
+            when Hash
+              raise NotImplementedError
+            when Symbol
+              relationship = @operation.resource_klass._relationship(include_item)
+              case relationship
+              when JSONAPI::Relationship::ToOne
+                raise NotImplementedError
+              when JSONAPI::Relationship::ToMany
+                authorizer.include_has_many_resource(relationship.resource_klass._model_class)
+              else
+                raise "Unexpected relationship type: #{relationship.inspect}"
+              end
+            else
+              raise "Unknown include directive: #{include_item}"
+            end
+          end
+        end
       end
 
       def authorize_show

--- a/lib/jsonapi/authorization/authorizing_operations_processor.rb
+++ b/lib/jsonapi/authorization/authorizing_operations_processor.rb
@@ -287,11 +287,11 @@ module JSONAPI
               relationship.relation_name(@operation.options[:context])
             )
             return if related_record.nil?
-            authorizer.include_has_one_resource(related_record, source_record)
+            authorizer.include_has_one_resource(source_record, related_record)
           when JSONAPI::Relationship::ToMany
             authorizer.include_has_many_resource(
-              relationship.resource_klass._model_class,
-              source_record
+              source_record,
+              relationship.resource_klass._model_class
             )
           else
             raise "Unexpected relationship type: #{relationship.inspect}"

--- a/lib/jsonapi/authorization/default_pundit_authorizer.rb
+++ b/lib/jsonapi/authorization/default_pundit_authorizer.rb
@@ -207,6 +207,19 @@ module JSONAPI
       def include_has_many_resource(record_class)
         ::Pundit.authorize(user, record_class, 'index?')
       end
+
+      # Any request including <tt>?include=another-resource</tt>
+      #
+      # This will be called for each has_one relationship if the include goes
+      # deeper than one level until some authorization fails or the include
+      # directive has been travelled completely.
+      #
+      # ==== Parameters
+      #
+      # * +related_record+ - The associated record to return
+      def include_has_one_resource(record_class)
+        raise NotImplementedError
+      end
     end
   end
 end

--- a/lib/jsonapi/authorization/default_pundit_authorizer.rb
+++ b/lib/jsonapi/authorization/default_pundit_authorizer.rb
@@ -204,7 +204,9 @@ module JSONAPI
       #
       # * +record_class+ - The underlying record class for the relationships
       #                    resource.
-      def include_has_many_resource(record_class)
+      # * +source_record+ — The source relationship record, e.g. an Article in
+      #                     article.comments check
+      def include_has_many_resource(record_class, source_record)
         ::Pundit.authorize(user, record_class, 'index?')
       end
 
@@ -217,7 +219,9 @@ module JSONAPI
       # ==== Parameters
       #
       # * +related_record+ - The associated record to return
-      def include_has_one_resource(related_record)
+      # * +source_record+ — The source relationship record, e.g. an Article in
+      #                     article.author check
+      def include_has_one_resource(related_record, source_record)
         ::Pundit.authorize(user, related_record, 'show?')
       end
     end

--- a/lib/jsonapi/authorization/default_pundit_authorizer.rb
+++ b/lib/jsonapi/authorization/default_pundit_authorizer.rb
@@ -190,6 +190,23 @@ module JSONAPI
       def remove_to_one_relationship(source_record, related_record)
         raise NotImplementedError
       end
+
+      # Any request including <tt>?include=other-resources</tt>
+      #
+      # This will be called for each has_many relationship if the include goes
+      # deeper than one level until some authorization fails or the include
+      # directive has been travelled completely.
+      #
+      # We can't pass all the records of a +has_many+ association here due to
+      # performance reasons, so the class is passed instead.
+      #
+      # ==== Parameters
+      #
+      # * +record_class+ - The underlying record class for the relationships
+      #                    resource.
+      def include_has_many_resource(record_class)
+        raise NotImplementedError
+      end
     end
   end
 end

--- a/lib/jsonapi/authorization/default_pundit_authorizer.rb
+++ b/lib/jsonapi/authorization/default_pundit_authorizer.rb
@@ -205,7 +205,7 @@ module JSONAPI
       # * +record_class+ - The underlying record class for the relationships
       #                    resource.
       def include_has_many_resource(record_class)
-        raise NotImplementedError
+        ::Pundit.authorize(user, record_class, 'index?')
       end
     end
   end

--- a/lib/jsonapi/authorization/default_pundit_authorizer.rb
+++ b/lib/jsonapi/authorization/default_pundit_authorizer.rb
@@ -217,8 +217,8 @@ module JSONAPI
       # ==== Parameters
       #
       # * +related_record+ - The associated record to return
-      def include_has_one_resource(record_class)
-        raise NotImplementedError
+      def include_has_one_resource(related_record)
+        ::Pundit.authorize(user, related_record, 'show?')
       end
     end
   end

--- a/lib/jsonapi/authorization/default_pundit_authorizer.rb
+++ b/lib/jsonapi/authorization/default_pundit_authorizer.rb
@@ -202,11 +202,11 @@ module JSONAPI
       #
       # ==== Parameters
       #
-      # * +record_class+ - The underlying record class for the relationships
-      #                    resource.
       # * +source_record+ — The source relationship record, e.g. an Article in
       #                     article.comments check
-      def include_has_many_resource(record_class, source_record)
+      # * +record_class+ - The underlying record class for the relationships
+      #                    resource.
+      def include_has_many_resource(source_record, record_class)
         ::Pundit.authorize(user, record_class, 'index?')
       end
 
@@ -218,10 +218,10 @@ module JSONAPI
       #
       # ==== Parameters
       #
-      # * +related_record+ - The associated record to return
       # * +source_record+ — The source relationship record, e.g. an Article in
       #                     article.author check
-      def include_has_one_resource(related_record, source_record)
+      # * +related_record+ - The associated record to return
+      def include_has_one_resource(source_record, related_record)
         ::Pundit.authorize(user, related_record, 'show?')
       end
     end

--- a/spec/dummy/app/models/article.rb
+++ b/spec/dummy/app/models/article.rb
@@ -1,4 +1,8 @@
 class Article < ActiveRecord::Base
   has_many :comments
   belongs_to :author, class_name: 'User'
+
+  # Hack for easy include directive checks
+  has_many :articles, -> { limit(2) }, foreign_key: :id
+  has_one :article, foreign_key: :id
 end

--- a/spec/dummy/app/models/article.rb
+++ b/spec/dummy/app/models/article.rb
@@ -6,4 +6,5 @@ class Article < ActiveRecord::Base
   has_many :articles, -> { limit(2) }, foreign_key: :id
   has_one :article, foreign_key: :id
   has_one :non_existing_article, -> { none }, class_name: 'Article', foreign_key: :id
+  has_many :empty_articles, -> { none }, class_name: 'Article', foreign_key: :id
 end

--- a/spec/dummy/app/models/article.rb
+++ b/spec/dummy/app/models/article.rb
@@ -5,4 +5,5 @@ class Article < ActiveRecord::Base
   # Hack for easy include directive checks
   has_many :articles, -> { limit(2) }, foreign_key: :id
   has_one :article, foreign_key: :id
+  has_one :non_existing_article, -> { none }, class_name: 'Article', foreign_key: :id
 end

--- a/spec/dummy/app/models/article.rb
+++ b/spec/dummy/app/models/article.rb
@@ -7,4 +7,14 @@ class Article < ActiveRecord::Base
   has_one :article, foreign_key: :id
   has_one :non_existing_article, -> { none }, class_name: 'Article', foreign_key: :id
   has_many :empty_articles, -> { none }, class_name: 'Article', foreign_key: :id
+
+  # Setting blank_value attribute is an easy way to test that authorizations
+  # work even when the model has validation errors
+  validate :blank_value_must_be_blank
+
+  private
+
+  def blank_value_must_be_blank
+    errors.add(:blank_value, 'must be blank') unless blank_value.blank?
+  end
 end

--- a/spec/dummy/app/models/comment.rb
+++ b/spec/dummy/app/models/comment.rb
@@ -1,3 +1,4 @@
 class Comment < ActiveRecord::Base
   belongs_to :article
+  belongs_to :author, class_name: 'User'
 end

--- a/spec/dummy/app/models/user.rb
+++ b/spec/dummy/app/models/user.rb
@@ -1,4 +1,4 @@
 class User < ActiveRecord::Base
-  has_many :articles, as: :author
-  has_many :comments, as: :author
+  has_many :articles, foreign_key: :author_id
+  has_many :comments, foreign_key: :author_id
 end

--- a/spec/dummy/app/models/user.rb
+++ b/spec/dummy/app/models/user.rb
@@ -1,3 +1,4 @@
 class User < ActiveRecord::Base
   has_many :articles, as: :author
+  has_many :comments, as: :author
 end

--- a/spec/dummy/app/resources/article_resource.rb
+++ b/spec/dummy/app/resources/article_resource.rb
@@ -7,4 +7,5 @@ class ArticleResource < JSONAPI::Resource
   # # Hack for easy include directive checks
   has_many :articles
   has_one :article
+  has_one :non_existing_article, class_name: 'Article', foreign_key_on: :related
 end

--- a/spec/dummy/app/resources/article_resource.rb
+++ b/spec/dummy/app/resources/article_resource.rb
@@ -9,4 +9,8 @@ class ArticleResource < JSONAPI::Resource
   has_one :article
   has_one :non_existing_article, class_name: 'Article', foreign_key_on: :related
   has_many :empty_articles, class_name: 'Article', foreign_key_on: :related
+
+  # Setting this attribute is an easy way to test that authorizations work even
+  # when the model has validation errors
+  attributes :blank_value
 end

--- a/spec/dummy/app/resources/article_resource.rb
+++ b/spec/dummy/app/resources/article_resource.rb
@@ -3,4 +3,8 @@ class ArticleResource < JSONAPI::Resource
 
   has_many :comments, acts_as_set: true
   has_one :author, class_name: 'User'
+
+  # # Hack for easy include directive checks
+  has_many :articles
+  has_one :article
 end

--- a/spec/dummy/app/resources/article_resource.rb
+++ b/spec/dummy/app/resources/article_resource.rb
@@ -8,4 +8,5 @@ class ArticleResource < JSONAPI::Resource
   has_many :articles
   has_one :article
   has_one :non_existing_article, class_name: 'Article', foreign_key_on: :related
+  has_many :empty_articles, class_name: 'Article', foreign_key_on: :related
 end

--- a/spec/dummy/app/resources/user_resource.rb
+++ b/spec/dummy/app/resources/user_resource.rb
@@ -1,3 +1,5 @@
 class UserResource < JSONAPI::Resource
   include JSONAPI::Authorization::PunditScopedResource
+
+  has_many :comments
 end

--- a/spec/dummy/db/migrate/20160125083537_create_models.rb
+++ b/spec/dummy/db/migrate/20160125083537_create_models.rb
@@ -2,6 +2,7 @@ class CreateModels < ActiveRecord::Migration
   def change
     create_table :comments do |t|
       t.belongs_to :article
+      t.belongs_to :author
     end
 
     create_table :users do |t|

--- a/spec/dummy/db/migrate/20160125083537_create_models.rb
+++ b/spec/dummy/db/migrate/20160125083537_create_models.rb
@@ -10,6 +10,7 @@ class CreateModels < ActiveRecord::Migration
 
     create_table :articles do |t|
       t.references :author
+      t.string :blank_value
     end
   end
 end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -15,6 +15,7 @@ ActiveRecord::Schema.define(version: 20160125083537) do
 
   create_table "articles", force: :cascade do |t|
     t.integer "author_id"
+    t.string  "blank_value"
   end
 
   create_table "comments", force: :cascade do |t|

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -19,6 +19,7 @@ ActiveRecord::Schema.define(version: 20160125083537) do
 
   create_table "comments", force: :cascade do |t|
     t.integer "article_id"
+    t.integer "author_id"
   end
 
   create_table "users", force: :cascade do |t|

--- a/spec/fixtures/articles.yml
+++ b/spec/fixtures/articles.yml
@@ -3,7 +3,5 @@ article_with_comments: {}
 article_without_comments: {}
 article_with_author:
   author: user_with_articles
-article_with_everything:
-  author: user_with_articles_and_comments
 article_without_author:
   author: ~

--- a/spec/fixtures/articles.yml
+++ b/spec/fixtures/articles.yml
@@ -2,6 +2,6 @@
 article_with_comments: {}
 article_without_comments: {}
 article_with_author:
-  author: user_1
+  author: user_with_articles
 article_without_author:
   author: ~

--- a/spec/fixtures/articles.yml
+++ b/spec/fixtures/articles.yml
@@ -3,5 +3,7 @@ article_with_comments: {}
 article_without_comments: {}
 article_with_author:
   author: user_with_articles
+article_with_everything:
+  author: user_with_articles_and_comments
 article_without_author:
   author: ~

--- a/spec/fixtures/comments.yml
+++ b/spec/fixtures/comments.yml
@@ -7,9 +7,4 @@ comment_2:
   author: user_with_comments
 comment_3:
   article: article_with_comments
-  author: user_with_articles_and_comments
-comment_4:
-  article: article_with_everything
-  author: user_with_articles_and_comments
-comment_5:
-  article: article_with_everything
+  author: user_with_comments

--- a/spec/fixtures/comments.yml
+++ b/spec/fixtures/comments.yml
@@ -7,4 +7,9 @@ comment_2:
   author: user_with_comments
 comment_3:
   article: article_with_comments
-  author: user_with_comments
+  author: user_with_articles_and_comments
+comment_4:
+  article: article_with_everything
+  author: user_with_articles_and_comments
+comment_5:
+  article: article_with_everything

--- a/spec/fixtures/comments.yml
+++ b/spec/fixtures/comments.yml
@@ -1,7 +1,10 @@
 ---
 comment_1:
   article: article_with_comments
+  author: user_with_comments
 comment_2:
   article: article_with_comments
+  author: user_with_comments
 comment_3:
   article: article_with_comments
+  author: user_with_comments

--- a/spec/fixtures/users.yml
+++ b/spec/fixtures/users.yml
@@ -1,3 +1,4 @@
 ---
 user_with_articles: {}
 user_with_comments: {}
+user_with_articles_and_comments: {}

--- a/spec/fixtures/users.yml
+++ b/spec/fixtures/users.yml
@@ -1,4 +1,3 @@
 ---
 user_with_articles: {}
 user_with_comments: {}
-user_with_articles_and_comments: {}

--- a/spec/fixtures/users.yml
+++ b/spec/fixtures/users.yml
@@ -1,2 +1,3 @@
 ---
-user_1: {}
+user_with_articles: {}
+user_with_comments: {}

--- a/spec/jsonapi/authorization/default_pundit_authorizer_spec.rb
+++ b/spec/jsonapi/authorization/default_pundit_authorizer_spec.rb
@@ -289,7 +289,7 @@ RSpec.describe JSONAPI::Authorization::DefaultPunditAuthorizer do
     let(:record_class) { Article }
     let(:source_record) { Comment.new }
     subject(:method_call) do
-      -> { authorizer.include_has_many_resource(record_class, source_record) }
+      -> { authorizer.include_has_many_resource(source_record, record_class) }
     end
 
     context 'authorized for index? on record class' do
@@ -307,7 +307,7 @@ RSpec.describe JSONAPI::Authorization::DefaultPunditAuthorizer do
     let(:related_record) { Article.new }
     let(:source_record) { Comment.new }
     subject(:method_call) do
-      -> { authorizer.include_has_one_resource(related_record, source_record) }
+      -> { authorizer.include_has_one_resource(source_record, related_record) }
     end
 
     context 'authorized for show? on record' do

--- a/spec/jsonapi/authorization/default_pundit_authorizer_spec.rb
+++ b/spec/jsonapi/authorization/default_pundit_authorizer_spec.rb
@@ -301,4 +301,20 @@ RSpec.describe JSONAPI::Authorization::DefaultPunditAuthorizer do
       it { is_expected.to raise_error(::Pundit::NotAuthorizedError) }
     end
   end
+
+  describe '#include_has_one_resource' do
+    subject(:method_call) do
+      -> { authorizer.include_has_one_resource(source_record) }
+    end
+
+    context 'authorized for show? on record' do
+      before { allow_action('show?', source_record) }
+      it { is_expected.not_to raise_error }
+    end
+
+    context 'unauthorized for show? on record' do
+      before { disallow_action('show?', source_record) }
+      it { is_expected.to raise_error(::Pundit::NotAuthorizedError) }
+    end
+  end
 end

--- a/spec/jsonapi/authorization/default_pundit_authorizer_spec.rb
+++ b/spec/jsonapi/authorization/default_pundit_authorizer_spec.rb
@@ -286,34 +286,37 @@ RSpec.describe JSONAPI::Authorization::DefaultPunditAuthorizer do
   end
 
   describe '#include_has_many_resource' do
-    let(:source_class) { source_record.class }
+    let(:record_class) { Article }
+    let(:source_record) { Comment.new }
     subject(:method_call) do
-      -> { authorizer.include_has_many_resource(source_class) }
+      -> { authorizer.include_has_many_resource(record_class, source_record) }
     end
 
     context 'authorized for index? on record class' do
-      before { allow_action('index?', source_class) }
+      before { allow_action('index?', record_class) }
       it { is_expected.not_to raise_error }
     end
 
     context 'unauthorized for index? on record class' do
-      before { disallow_action('index?', source_class) }
+      before { disallow_action('index?', record_class) }
       it { is_expected.to raise_error(::Pundit::NotAuthorizedError) }
     end
   end
 
   describe '#include_has_one_resource' do
+    let(:related_record) { Article.new }
+    let(:source_record) { Comment.new }
     subject(:method_call) do
-      -> { authorizer.include_has_one_resource(source_record) }
+      -> { authorizer.include_has_one_resource(related_record, source_record) }
     end
 
     context 'authorized for show? on record' do
-      before { allow_action('show?', source_record) }
+      before { allow_action('show?', related_record) }
       it { is_expected.not_to raise_error }
     end
 
     context 'unauthorized for show? on record' do
-      before { disallow_action('show?', source_record) }
+      before { disallow_action('show?', related_record) }
       it { is_expected.to raise_error(::Pundit::NotAuthorizedError) }
     end
   end

--- a/spec/jsonapi/authorization/default_pundit_authorizer_spec.rb
+++ b/spec/jsonapi/authorization/default_pundit_authorizer_spec.rb
@@ -284,4 +284,21 @@ RSpec.describe JSONAPI::Authorization::DefaultPunditAuthorizer do
       it { is_expected.to raise_error(::Pundit::NotAuthorizedError) }
     end
   end
+
+  describe '#include_has_many_resource' do
+    let(:source_class) { source_record.class }
+    subject(:method_call) do
+      -> { authorizer.include_has_many_resource(source_class) }
+    end
+
+    context 'authorized for index? on record class' do
+      before { allow_action('index?', source_class) }
+      it { is_expected.not_to raise_error }
+    end
+
+    context 'unauthorized for index? on record class' do
+      before { disallow_action('index?', source_class) }
+      it { is_expected.to raise_error(::Pundit::NotAuthorizedError) }
+    end
+  end
 end

--- a/spec/requests/included_resources_spec.rb
+++ b/spec/requests/included_resources_spec.rb
@@ -195,4 +195,11 @@ RSpec.describe 'including resources alongside normal operations', type: :request
 
     include_examples :include_directive_tests
   end
+
+  describe 'GET /articles/:id/article' do
+    subject(:last_response) { get("/articles/#{article.id}/article?include=#{include_query}") }
+    let(:chained_authorizer) { allow_operation('show_related_resource', article, article) }
+
+    include_examples :include_directive_tests
+  end
 end

--- a/spec/requests/included_resources_spec.rb
+++ b/spec/requests/included_resources_spec.rb
@@ -188,6 +188,7 @@ RSpec.describe 'including resources alongside normal operations', type: :request
 
     let(:article) {
       Article.create(
+        external_id: "indifferent_external_id",
         author: User.create(
           comments: Array.new(2) { Comment.create }
         ),
@@ -204,6 +205,7 @@ RSpec.describe 'including resources alongside normal operations', type: :request
   describe 'GET /articles/:id' do
     let(:article) {
       Article.create(
+        external_id: "indifferent_external_id",
         author: User.create(
           comments: Array.new(2) { Comment.create }
         ),
@@ -211,7 +213,7 @@ RSpec.describe 'including resources alongside normal operations', type: :request
       )
     }
 
-    subject(:last_response) { get("/articles/#{article.id}?include=#{include_query}") }
+    subject(:last_response) { get("/articles/#{article.external_id}?include=#{include_query}") }
     let!(:chained_authorizer) { allow_operation('show', article) }
 
     include_examples :include_directive_tests
@@ -220,6 +222,7 @@ RSpec.describe 'including resources alongside normal operations', type: :request
   describe 'PATCH /articles/:id' do
     let(:article) {
       Article.create(
+        external_id: "indifferent_external_id",
         author: User.create(
           comments: Array.new(2) { Comment.create }
         ),
@@ -233,13 +236,13 @@ RSpec.describe 'including resources alongside normal operations', type: :request
       {
         "data": {
           "type": "articles",
-          "id": "#{article.id}",
+          "id": "#{article.external_id}",
           "attributes": #{attributes_json}
         }
       }
       EOS
     end
-    subject(:last_response) { patch("/articles/#{article.id}?include=#{include_query}", json) }
+    subject(:last_response) { patch("/articles/#{article.external_id}?include=#{include_query}", json) }
     let!(:chained_authorizer) { allow_operation('replace_fields', article, []) }
 
     include_examples :include_directive_tests
@@ -270,6 +273,7 @@ RSpec.describe 'including resources alongside normal operations', type: :request
       {
         "data": {
           "type": "articles",
+          "id": "indifferent_external_id",
           "attributes": #{attributes_json},
           "relationships": {
             "comments": {
@@ -310,6 +314,7 @@ RSpec.describe 'including resources alongside normal operations', type: :request
   describe 'GET /articles/:id/articles' do
     let(:article) {
       Article.create(
+        external_id: "indifferent_external_id",
         author: User.create(
           comments: Array.new(2) { Comment.create }
         ),
@@ -319,7 +324,7 @@ RSpec.describe 'including resources alongside normal operations', type: :request
 
     let(:article_policy_scope) { Article.where(id: article.id) }
 
-    subject(:last_response) { get("/articles/#{article.id}/articles?include=#{include_query}") }
+    subject(:last_response) { get("/articles/#{article.external_id}/articles?include=#{include_query}") }
     let!(:chained_authorizer) { allow_operation('show_related_resources', article) }
 
     include_examples :include_directive_tests
@@ -328,6 +333,7 @@ RSpec.describe 'including resources alongside normal operations', type: :request
   describe 'GET /articles/:id/article' do
     let(:article) {
       Article.create(
+        external_id: "indifferent_external_id",
         author: User.create(
           comments: Array.new(2) { Comment.create }
         ),
@@ -335,7 +341,7 @@ RSpec.describe 'including resources alongside normal operations', type: :request
       )
     }
 
-    subject(:last_response) { get("/articles/#{article.id}/article?include=#{include_query}") }
+    subject(:last_response) { get("/articles/#{article.external_id}/article?include=#{include_query}") }
     let!(:chained_authorizer) { allow_operation('show_related_resource', article, article) }
 
     include_examples :include_directive_tests

--- a/spec/requests/included_resources_spec.rb
+++ b/spec/requests/included_resources_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe 'including resources alongside normal operations', type: :request
   include AuthorizationStubs
   fixtures :all
 
-  let(:article) { Article.all.sample }
+  let(:article) { articles(:article_with_comments) }
 
   subject { last_response }
   let(:json_included) { JSON.parse(last_response.body)['included'] }
@@ -17,10 +17,7 @@ RSpec.describe 'including resources alongside normal operations', type: :request
     header 'Content-Type', 'application/vnd.api+json'
   end
 
-  describe 'GET /articles' do
-    subject(:last_response) { get("/articles?include=#{include_query}") }
-    let(:chained_authorizer) { allow_operation('find', Article) }
-
+  shared_examples_for :include_directive_tests do
     describe 'one-level deep has_many relationship' do
       let(:include_query) { 'comments' }
 
@@ -46,5 +43,19 @@ RSpec.describe 'including resources alongside normal operations', type: :request
         end
       end
     end
+  end
+
+  describe 'GET /articles' do
+    subject(:last_response) { get("/articles?include=#{include_query}") }
+    let(:chained_authorizer) { allow_operation('find', Article) }
+
+    include_examples :include_directive_tests
+  end
+
+  describe 'GET /articles/:id' do
+    subject(:last_response) { get("/articles/#{article.id}?include=#{include_query}") }
+    let(:chained_authorizer) { allow_operation('show', article) }
+
+    include_examples :include_directive_tests
   end
 end

--- a/spec/requests/included_resources_spec.rb
+++ b/spec/requests/included_resources_spec.rb
@@ -215,6 +215,15 @@ RSpec.describe 'including resources alongside normal operations', type: :request
         end
       end
     end
+
+    context 'the request has failed already', pending: 'How to test this' do
+      let(:include_query) { 'author.comments' }
+
+      it 'does not run include authorizations' do
+        expect(last_response).not_to be_forbidden
+        expect(last_response).not_to be_successful
+      end
+    end
   end
 
   describe 'GET /articles' do

--- a/spec/requests/included_resources_spec.rb
+++ b/spec/requests/included_resources_spec.rb
@@ -33,9 +33,9 @@ RSpec.describe 'including resources alongside normal operations', type: :request
         before { disallow_operation('include_has_many_resource', any_args, authorizer: chained_authorizer) }
         after do
           if article.present?
-            expect(chained_authorizer).to have_received(:include_has_many_resource).with(Comment, article)
+            expect(chained_authorizer).to have_received(:include_has_many_resource).with(article, Comment)
           else
-            expect(chained_authorizer).to have_received(:include_has_many_resource).with(Comment, an_instance_of(Article))
+            expect(chained_authorizer).to have_received(:include_has_many_resource).with(an_instance_of(Article), Comment)
           end
         end
 
@@ -45,7 +45,7 @@ RSpec.describe 'including resources alongside normal operations', type: :request
       context 'authorized for include_has_many_resource for Comment' do
         before { allow_operation('include_has_many_resource', any_args, authorizer: chained_authorizer) }
         after do
-          expect(chained_authorizer).to have_received(:include_has_many_resource).with(Comment, article)
+          expect(chained_authorizer).to have_received(:include_has_many_resource).with(article, Comment)
         end
         it { is_expected.to be_successful }
 
@@ -66,9 +66,9 @@ RSpec.describe 'including resources alongside normal operations', type: :request
         after do
           expect(chained_authorizer).to have_received(:include_has_one_resource).with(any_args)
           if article.present?
-            expect(chained_authorizer).to have_received(:include_has_one_resource).with(article.author, article)
+            expect(chained_authorizer).to have_received(:include_has_one_resource).with(article, article.author)
           else
-            expect(chained_authorizer).to have_received(:include_has_one_resource).with(an_instance_of(User), an_instance_of(Article))
+            expect(chained_authorizer).to have_received(:include_has_one_resource).with(an_instance_of(Article), an_instance_of(User))
           end
         end
         it { is_expected.to be_forbidden }
@@ -77,7 +77,7 @@ RSpec.describe 'including resources alongside normal operations', type: :request
       context 'authorized for include_has_one_resource for article.author' do
         before { allow_operation('include_has_one_resource', any_args, authorizer: chained_authorizer) }
         after do
-          expect(chained_authorizer).to have_received(:include_has_one_resource).with(article.author, article)
+          expect(chained_authorizer).to have_received(:include_has_one_resource).with(article, article.author)
         end
         it { is_expected.to be_successful }
 
@@ -99,9 +99,9 @@ RSpec.describe 'including resources alongside normal operations', type: :request
         after do
           expect(chained_authorizer).to have_received(:include_has_one_resource).with(any_args)
           if article.present?
-            expect(chained_authorizer).to have_received(:include_has_one_resource).with(article.author, article)
+            expect(chained_authorizer).to have_received(:include_has_one_resource).with(article, article.author)
           else
-            expect(chained_authorizer).to have_received(:include_has_one_resource).with(an_instance_of(User), an_instance_of(Article))
+            expect(chained_authorizer).to have_received(:include_has_one_resource).with(an_instance_of(Article), an_instance_of(User))
           end
         end
 
@@ -116,9 +116,9 @@ RSpec.describe 'including resources alongside normal operations', type: :request
         after do
           expect(chained_authorizer).to have_received(:include_has_many_resource).with(any_args)
           if article.present?
-            expect(chained_authorizer).to have_received(:include_has_many_resource).with(Comment, article)
+            expect(chained_authorizer).to have_received(:include_has_many_resource).with(article, Comment)
           else
-            expect(chained_authorizer).to have_received(:include_has_many_resource).with(Comment, an_instance_of(Article))
+            expect(chained_authorizer).to have_received(:include_has_many_resource).with(an_instance_of(Article), Comment)
           end
         end
 
@@ -131,8 +131,8 @@ RSpec.describe 'including resources alongside normal operations', type: :request
           allow_operation('include_has_many_resource', any_args, authorizer: chained_authorizer)
         end
         after do
-          expect(chained_authorizer).to have_received(:include_has_one_resource).with(article.author, article)
-          expect(chained_authorizer).to have_received(:include_has_many_resource).with(Comment, article)
+          expect(chained_authorizer).to have_received(:include_has_one_resource).with(article, article.author)
+          expect(chained_authorizer).to have_received(:include_has_many_resource).with(article, Comment)
         end
 
         it { is_expected.to be_successful }
@@ -160,7 +160,7 @@ RSpec.describe 'including resources alongside normal operations', type: :request
         after do
           expect(chained_authorizer).to have_received(:include_has_one_resource).with(any_args)
           if article.present?
-            expect(chained_authorizer).to have_received(:include_has_one_resource).with(article.author, article)
+            expect(chained_authorizer).to have_received(:include_has_one_resource).with(article, article.author)
           end
         end
 
@@ -172,7 +172,7 @@ RSpec.describe 'including resources alongside normal operations', type: :request
         after do
           expect(chained_authorizer).to have_received(:include_has_one_resource).with(any_args)
           if article.present?
-            expect(chained_authorizer).to have_received(:include_has_one_resource).with(article.author, article)
+            expect(chained_authorizer).to have_received(:include_has_one_resource).with(article, article.author)
           end
         end
 
@@ -180,9 +180,9 @@ RSpec.describe 'including resources alongside normal operations', type: :request
           before { disallow_operation('include_has_many_resource', any_args, authorizer: chained_authorizer) }
           after do
             if article.present?
-              expect(chained_authorizer).to have_received(:include_has_many_resource).with(Comment, article.author)
+              expect(chained_authorizer).to have_received(:include_has_many_resource).with(article.author, Comment)
             else
-              expect(chained_authorizer).to have_received(:include_has_many_resource).with(Comment, an_instance_of(User))
+              expect(chained_authorizer).to have_received(:include_has_many_resource).with(an_instance_of(User), Comment)
             end
           end
 
@@ -192,7 +192,7 @@ RSpec.describe 'including resources alongside normal operations', type: :request
         context 'authorized for second relationship' do
           before { allow_operation('include_has_many_resource', any_args, authorizer: chained_authorizer) }
           after do
-            expect(chained_authorizer).to have_received(:include_has_many_resource).with(Comment, article.author)
+            expect(chained_authorizer).to have_received(:include_has_many_resource).with(article.author, Comment)
           end
 
           it { is_expected.to be_successful }
@@ -231,9 +231,9 @@ RSpec.describe 'including resources alongside normal operations', type: :request
           before { disallow_operation('include_has_many_resource', any_args, authorizer: chained_authorizer) }
           after do
             if article.present?
-              expect(chained_authorizer).to have_received(:include_has_many_resource).with(Article, article)
+              expect(chained_authorizer).to have_received(:include_has_many_resource).with(article, Article)
             else
-              expect(chained_authorizer).to have_received(:include_has_many_resource).with(Article, an_instance_of(Article))
+              expect(chained_authorizer).to have_received(:include_has_many_resource).with(an_instance_of(Article), Article)
             end
           end
           it { is_expected.to be_forbidden }
@@ -242,7 +242,7 @@ RSpec.describe 'including resources alongside normal operations', type: :request
         context 'authorized for first relationship' do
           before { allow_operation('include_has_many_resource', any_args, authorizer: chained_authorizer) }
           after do
-            expect(chained_authorizer).to have_received(:include_has_many_resource).with(Article, article)
+            expect(chained_authorizer).to have_received(:include_has_many_resource).with(article, Article)
           end
           it { is_expected.to be_successful }
         end

--- a/spec/requests/included_resources_spec.rb
+++ b/spec/requests/included_resources_spec.rb
@@ -221,7 +221,7 @@ RSpec.describe 'including resources alongside normal operations', type: :request
     subject(:last_response) { get("/articles?include=#{include_query}") }
     let!(:chained_authorizer) { allow_operation('find', Article) }
 
-    let!(:article) {
+    let(:article) {
       Article.create(
         author: User.create(
           comments: Array.new(2) { Comment.create }
@@ -237,7 +237,7 @@ RSpec.describe 'including resources alongside normal operations', type: :request
   end
 
   describe 'GET /articles/:id' do
-    let!(:article) {
+    let(:article) {
       Article.create(
         author: User.create(
           comments: Array.new(2) { Comment.create }
@@ -253,7 +253,7 @@ RSpec.describe 'including resources alongside normal operations', type: :request
   end
 
   describe 'PATCH /articles/:id' do
-    let!(:article) {
+    let(:article) {
       Article.create(
         author: User.create(
           comments: Array.new(2) { Comment.create }
@@ -270,12 +270,12 @@ RSpec.describe 'including resources alongside normal operations', type: :request
   end
 
   describe 'POST /articles/:id' do
-    let!(:existing_author) do
+    let(:existing_author) do
       User.create(
         comments: Array.new(2) { Comment.create }
       )
     end
-    let!(:existing_comments) do
+    let(:existing_comments) do
       Array.new(2) { Comment.create }
     end
     let(:json) do
@@ -311,7 +311,7 @@ RSpec.describe 'including resources alongside normal operations', type: :request
   end
 
   describe 'GET /articles/:id/articles' do
-    let!(:article) {
+    let(:article) {
       Article.create(
         author: User.create(
           comments: Array.new(2) { Comment.create }
@@ -329,7 +329,7 @@ RSpec.describe 'including resources alongside normal operations', type: :request
   end
 
   describe 'GET /articles/:id/article' do
-    let!(:article) {
+    let(:article) {
       Article.create(
         author: User.create(
           comments: Array.new(2) { Comment.create }

--- a/spec/requests/included_resources_spec.rb
+++ b/spec/requests/included_resources_spec.rb
@@ -116,7 +116,6 @@ RSpec.describe 'including resources alongside normal operations', type: :request
         before do
           allow_operation('include_has_one_resource', any_args, authorizer: chained_authorizer)
           allow_operation('include_has_many_resource', Comment, authorizer: chained_authorizer)
-          last_response
         end
         after do
           expect(chained_authorizer).to have_received(:include_has_one_resource).with(any_args)
@@ -173,7 +172,6 @@ RSpec.describe 'including resources alongside normal operations', type: :request
 
         context 'authorized for second relationship' do
           before { allow_operation('include_has_many_resource', Comment, authorizer: chained_authorizer) }
-          before { last_response }
           it { is_expected.to be_successful }
 
           let(:comments_policy_scope) { Comment.all }

--- a/spec/requests/included_resources_spec.rb
+++ b/spec/requests/included_resources_spec.rb
@@ -202,6 +202,20 @@ RSpec.describe 'including resources alongside normal operations', type: :request
 
         it { is_expected.to be_successful }
       end
+
+      context 'first level has_many is empty' do
+        let(:include_query) { 'empty-articles.comments' }
+
+        context 'unauthorized for first relationship' do
+          before { disallow_operation('include_has_many_resource', Article, authorizer: chained_authorizer) }
+          it { is_expected.to be_forbidden }
+        end
+
+        context 'authorized for first relationship' do
+          before { allow_operation('include_has_many_resource', Article, authorizer: chained_authorizer) }
+          it { is_expected.to be_successful }
+        end
+      end
     end
   end
 

--- a/spec/requests/included_resources_spec.rb
+++ b/spec/requests/included_resources_spec.rb
@@ -30,23 +30,14 @@ RSpec.describe 'including resources alongside normal operations', type: :request
       let(:comments_policy_scope) { Comment.all }
 
       context 'unauthorized for include_has_many_resource for Comment' do
-        before { disallow_operation('include_has_many_resource', any_args, authorizer: chained_authorizer) }
-        after do
-          if article.present?
-            expect(chained_authorizer).to have_received(:include_has_many_resource).with(article, Comment)
-          else
-            expect(chained_authorizer).to have_received(:include_has_many_resource).with(an_instance_of(Article), Comment)
-          end
-        end
+        before { disallow_operation('include_has_many_resource', an_instance_of(Article), Comment, authorizer: chained_authorizer) }
 
         it { is_expected.to be_forbidden }
       end
 
       context 'authorized for include_has_many_resource for Comment' do
-        before { allow_operation('include_has_many_resource', any_args, authorizer: chained_authorizer) }
-        after do
-          expect(chained_authorizer).to have_received(:include_has_many_resource).with(article, Comment)
-        end
+        before { allow_operation('include_has_many_resource', an_instance_of(Article), Comment, authorizer: chained_authorizer) }
+
         it { is_expected.to be_successful }
 
         let(:comments_policy_scope) { Comment.limit(1) }
@@ -62,23 +53,14 @@ RSpec.describe 'including resources alongside normal operations', type: :request
       let(:include_query) { 'author' }
 
       context 'unauthorized for include_has_one_resource for article.author' do
-        before { disallow_operation('include_has_one_resource', any_args, authorizer: chained_authorizer) }
-        after do
-          expect(chained_authorizer).to have_received(:include_has_one_resource).with(any_args)
-          if article.present?
-            expect(chained_authorizer).to have_received(:include_has_one_resource).with(article, article.author)
-          else
-            expect(chained_authorizer).to have_received(:include_has_one_resource).with(an_instance_of(Article), an_instance_of(User))
-          end
-        end
+        before { disallow_operation('include_has_one_resource', an_instance_of(Article), an_instance_of(User), authorizer: chained_authorizer) }
+
         it { is_expected.to be_forbidden }
       end
 
       context 'authorized for include_has_one_resource for article.author' do
-        before { allow_operation('include_has_one_resource', any_args, authorizer: chained_authorizer) }
-        after do
-          expect(chained_authorizer).to have_received(:include_has_one_resource).with(article, article.author)
-        end
+        before { allow_operation('include_has_one_resource', an_instance_of(Article), an_instance_of(User), authorizer: chained_authorizer) }
+
         it { is_expected.to be_successful }
 
         it 'includes the associated author resource' do
@@ -94,15 +76,7 @@ RSpec.describe 'including resources alongside normal operations', type: :request
 
       context 'unauthorized for include_has_one_resource for article.author' do
         before do
-          disallow_operation('include_has_one_resource', any_args, authorizer: chained_authorizer)
-        end
-        after do
-          expect(chained_authorizer).to have_received(:include_has_one_resource).with(any_args)
-          if article.present?
-            expect(chained_authorizer).to have_received(:include_has_one_resource).with(article, article.author)
-          else
-            expect(chained_authorizer).to have_received(:include_has_one_resource).with(an_instance_of(Article), an_instance_of(User))
-          end
+          disallow_operation('include_has_one_resource', an_instance_of(Article), an_instance_of(User), authorizer: chained_authorizer)
         end
 
         it { is_expected.to be_forbidden }
@@ -110,16 +84,8 @@ RSpec.describe 'including resources alongside normal operations', type: :request
 
       context 'unauthorized for include_has_many_resource for Comment' do
         before do
-          allow_operation('include_has_one_resource', any_args, authorizer: chained_authorizer)
-          disallow_operation('include_has_many_resource', any_args, authorizer: chained_authorizer)
-        end
-        after do
-          expect(chained_authorizer).to have_received(:include_has_many_resource).with(any_args)
-          if article.present?
-            expect(chained_authorizer).to have_received(:include_has_many_resource).with(article, Comment)
-          else
-            expect(chained_authorizer).to have_received(:include_has_many_resource).with(an_instance_of(Article), Comment)
-          end
+          allow_operation('include_has_one_resource', an_instance_of(Article), an_instance_of(User), authorizer: chained_authorizer)
+          disallow_operation('include_has_many_resource', an_instance_of(Article), Comment, authorizer: chained_authorizer)
         end
 
         it { is_expected.to be_forbidden }
@@ -127,12 +93,8 @@ RSpec.describe 'including resources alongside normal operations', type: :request
 
       context 'authorized for both operations' do
         before do
-          allow_operation('include_has_one_resource', any_args, authorizer: chained_authorizer)
-          allow_operation('include_has_many_resource', any_args, authorizer: chained_authorizer)
-        end
-        after do
-          expect(chained_authorizer).to have_received(:include_has_one_resource).with(article, article.author)
-          expect(chained_authorizer).to have_received(:include_has_many_resource).with(article, Comment)
+          allow_operation('include_has_one_resource', an_instance_of(Article), an_instance_of(User), authorizer: chained_authorizer)
+          allow_operation('include_has_many_resource', an_instance_of(Article), Comment, authorizer: chained_authorizer)
         end
 
         it { is_expected.to be_successful }
@@ -156,44 +118,22 @@ RSpec.describe 'including resources alongside normal operations', type: :request
       let(:include_query) { 'author.comments' }
 
       context 'unauthorized for first relationship' do
-        before { disallow_operation('include_has_one_resource', any_args, authorizer: chained_authorizer) }
-        after do
-          expect(chained_authorizer).to have_received(:include_has_one_resource).with(any_args)
-          if article.present?
-            expect(chained_authorizer).to have_received(:include_has_one_resource).with(article, article.author)
-          end
-        end
+        before { disallow_operation('include_has_one_resource', an_instance_of(Article), an_instance_of(User), authorizer: chained_authorizer) }
 
         it { is_expected.to be_forbidden }
       end
 
       context 'authorized for first relationship' do
-        before { allow_operation('include_has_one_resource', any_args, authorizer: chained_authorizer) }
-        after do
-          expect(chained_authorizer).to have_received(:include_has_one_resource).with(any_args)
-          if article.present?
-            expect(chained_authorizer).to have_received(:include_has_one_resource).with(article, article.author)
-          end
-        end
+        before { allow_operation('include_has_one_resource', an_instance_of(Article), an_instance_of(User), authorizer: chained_authorizer) }
 
         context 'unauthorized for second relationship' do
-          before { disallow_operation('include_has_many_resource', any_args, authorizer: chained_authorizer) }
-          after do
-            if article.present?
-              expect(chained_authorizer).to have_received(:include_has_many_resource).with(article.author, Comment)
-            else
-              expect(chained_authorizer).to have_received(:include_has_many_resource).with(an_instance_of(User), Comment)
-            end
-          end
+          before { disallow_operation('include_has_many_resource', an_instance_of(User), Comment, authorizer: chained_authorizer) }
 
           it { is_expected.to be_forbidden }
         end
 
         context 'authorized for second relationship' do
-          before { allow_operation('include_has_many_resource', any_args, authorizer: chained_authorizer) }
-          after do
-            expect(chained_authorizer).to have_received(:include_has_many_resource).with(article.author, Comment)
-          end
+          before { allow_operation('include_has_many_resource', an_instance_of(User), Comment, authorizer: chained_authorizer) }
 
           it { is_expected.to be_successful }
 
@@ -228,22 +168,14 @@ RSpec.describe 'including resources alongside normal operations', type: :request
         let(:include_query) { 'empty-articles.comments' }
 
         context 'unauthorized for first relationship' do
-          before { disallow_operation('include_has_many_resource', any_args, authorizer: chained_authorizer) }
-          after do
-            if article.present?
-              expect(chained_authorizer).to have_received(:include_has_many_resource).with(article, Article)
-            else
-              expect(chained_authorizer).to have_received(:include_has_many_resource).with(an_instance_of(Article), Article)
-            end
-          end
+          before { disallow_operation('include_has_many_resource', an_instance_of(Article), Article, authorizer: chained_authorizer) }
+
           it { is_expected.to be_forbidden }
         end
 
         context 'authorized for first relationship' do
-          before { allow_operation('include_has_many_resource', any_args, authorizer: chained_authorizer) }
-          after do
-            expect(chained_authorizer).to have_received(:include_has_many_resource).with(article, Article)
-          end
+          before { allow_operation('include_has_many_resource', an_instance_of(Article), Article, authorizer: chained_authorizer) }
+
           it { is_expected.to be_successful }
         end
       end

--- a/spec/requests/included_resources_spec.rb
+++ b/spec/requests/included_resources_spec.rb
@@ -195,11 +195,19 @@ RSpec.describe 'including resources alongside normal operations', type: :request
         end
       end
     end
+
+    describe 'a deep relationship with empty relations' do
+      context 'first level has_one is nil' do
+        let(:include_query) { 'non-existing-article.comments' }
+
+        it { is_expected.to be_successful }
+      end
+    end
   end
 
   describe 'GET /articles' do
     subject(:last_response) { get("/articles?include=#{include_query}") }
-    let(:chained_authorizer) { allow_operation('find', Article) }
+    let!(:chained_authorizer) { allow_operation('find', Article) }
 
     let!(:article) {
       Article.create(
@@ -227,7 +235,7 @@ RSpec.describe 'including resources alongside normal operations', type: :request
     }
 
     subject(:last_response) { get("/articles/#{article.id}?include=#{include_query}") }
-    let(:chained_authorizer) { allow_operation('show', article) }
+    let!(:chained_authorizer) { allow_operation('show', article) }
 
     include_examples :include_directive_tests
   end
@@ -244,7 +252,7 @@ RSpec.describe 'including resources alongside normal operations', type: :request
 
     let(:json) { %({"data": { "type": "articles", "id": "#{article.id}" }}) }
     subject(:last_response) { patch("/articles/#{article.id}?include=#{include_query}", json) }
-    let(:chained_authorizer) { allow_operation('replace_fields', article, []) }
+    let!(:chained_authorizer) { allow_operation('replace_fields', article, []) }
 
     include_examples :include_directive_tests
   end
@@ -283,7 +291,7 @@ RSpec.describe 'including resources alongside normal operations', type: :request
     let(:article) { existing_author.articles.first }
 
     subject(:last_response) { post("/articles?include=#{include_query}", json) }
-    let(:chained_authorizer) do
+    let!(:chained_authorizer) do
       allow_operation('create_resource', Article, [existing_author, *existing_comments])
     end
 
@@ -303,7 +311,7 @@ RSpec.describe 'including resources alongside normal operations', type: :request
     let(:article_policy_scope) { Article.where(id: article.id) }
 
     subject(:last_response) { get("/articles/#{article.id}/articles?include=#{include_query}") }
-    let(:chained_authorizer) { allow_operation('show_related_resources', article) }
+    let!(:chained_authorizer) { allow_operation('show_related_resources', article) }
 
     include_examples :include_directive_tests
   end
@@ -319,7 +327,7 @@ RSpec.describe 'including resources alongside normal operations', type: :request
     }
 
     subject(:last_response) { get("/articles/#{article.id}/article?include=#{include_query}") }
-    let(:chained_authorizer) { allow_operation('show_related_resource', article, article) }
+    let!(:chained_authorizer) { allow_operation('show_related_resource', article, article) }
 
     include_examples :include_directive_tests
   end

--- a/spec/requests/included_resources_spec.rb
+++ b/spec/requests/included_resources_spec.rb
@@ -188,4 +188,11 @@ RSpec.describe 'including resources alongside normal operations', type: :request
 
     include_examples :include_directive_tests
   end
+
+  describe 'GET /articles/:id/articles' do
+    subject(:last_response) { get("/articles/#{article.id}/articles?include=#{include_query}") }
+    let(:chained_authorizer) { allow_operation('show_related_resources', article) }
+
+    include_examples :include_directive_tests
+  end
 end

--- a/spec/requests/included_resources_spec.rb
+++ b/spec/requests/included_resources_spec.rb
@@ -4,8 +4,6 @@ RSpec.describe 'including resources alongside normal operations', type: :request
   include AuthorizationStubs
   fixtures :all
 
-  let(:article) { articles(:article_with_everything) }
-
   subject { last_response }
   let(:json_included) { JSON.parse(last_response.body)['included'] }
 
@@ -22,6 +20,7 @@ RSpec.describe 'including resources alongside normal operations', type: :request
   shared_examples_for :include_directive_tests do
     describe 'one-level deep has_many relationship' do
       let(:include_query) { 'comments' }
+      let(:article) { articles(:article_with_comments) }
 
       let(:comments_policy_scope) { Comment.all }
       before do
@@ -48,6 +47,7 @@ RSpec.describe 'including resources alongside normal operations', type: :request
 
     describe 'one-level deep has_one relationship' do
       let(:include_query) { 'author' }
+      let(:article) { articles(:article_with_author) }
 
       context 'unauthorized for include_has_one_resource for article.author' do
         before { disallow_operation('include_has_one_resource', article.author, authorizer: chained_authorizer) }

--- a/spec/requests/included_resources_spec.rb
+++ b/spec/requests/included_resources_spec.rb
@@ -1,0 +1,50 @@
+require 'spec_helper'
+
+RSpec.describe 'including resources alongside normal operations', type: :request do
+  include AuthorizationStubs
+  fixtures :all
+
+  let(:article) { Article.all.sample }
+
+  subject { last_response }
+  let(:json_included) { JSON.parse(last_response.body)['included'] }
+
+  before do
+    allow_any_instance_of(ArticlePolicy::Scope).to receive(:resolve).and_return(Article.all)
+  end
+
+  before do
+    header 'Content-Type', 'application/vnd.api+json'
+  end
+
+  describe 'GET /articles' do
+    subject(:last_response) { get("/articles?include=#{include_query}") }
+    let(:chained_authorizer) { allow_operation('find', Article) }
+
+    describe 'one-level deep has_many relationship' do
+      let(:include_query) { 'comments' }
+
+      let(:comments_policy_scope) { Comment.all }
+      before do
+        allow_any_instance_of(CommentPolicy::Scope).to receive(:resolve).and_return(comments_policy_scope)
+      end
+
+      context 'unauthorized for include_has_many_resource for Comment' do
+        before { disallow_operation('include_has_many_resource', Comment, authorizer: chained_authorizer) }
+        it { is_expected.to be_forbidden }
+      end
+
+      context 'authorized for include_has_many_resource for Comment' do
+        before { allow_operation('include_has_many_resource', Comment, authorizer: chained_authorizer) }
+        it { is_expected.to be_ok }
+
+        let(:comments_policy_scope) { Comment.limit(1) }
+
+        it 'includes only comments allowed by policy scope' do
+          expect(json_included.length).to eq(1)
+          expect(json_included.first["id"]).to eq(comments_policy_scope.first.id.to_s)
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/resource_operations_spec.rb
+++ b/spec/requests/resource_operations_spec.rb
@@ -8,8 +8,7 @@ describe 'Resource operations', type: :request do
   let(:policy_scope) { Article.none }
 
   subject { last_response }
-  let(:json_body) { JSON.parse(last_response.body) }
-  let(:json_data) { json_body["data"] }
+  let(:json_data) { JSON.parse(last_response.body)["data"] }
 
   before do
     allow_any_instance_of(ArticlePolicy::Scope).to receive(:resolve).and_return(policy_scope)
@@ -36,33 +35,6 @@ describe 'Resource operations', type: :request do
       it 'returns results limited by policy scope' do
         expect(json_data.length).to eq(1)
         expect(json_data.first["id"]).to eq(article.id.to_s)
-      end
-    end
-
-    describe 'with ?include=comments' do
-      subject(:last_response) { get('/articles?include=comments') }
-      let(:chained_authorizer) { allow_operation('find', Article) }
-      let(:policy_scope) { Article.all }
-      let(:comments_policy_scope) { Comment.all }
-      before do
-        allow_any_instance_of(CommentPolicy::Scope).to receive(:resolve).and_return(comments_policy_scope)
-      end
-
-      context 'unauthorized for include_has_many_resource for Comment' do
-        before { disallow_operation('include_has_many_resource', Comment, authorizer: chained_authorizer) }
-        it { is_expected.to be_forbidden }
-      end
-
-      context 'authorized for include_has_many_resource for Comment' do
-        before { allow_operation('include_has_many_resource', Comment, authorizer: chained_authorizer) }
-        it { is_expected.to be_ok }
-
-        let(:comments_policy_scope) { Comment.limit(1) }
-
-        it 'includes only comments allowed by policy scope' do
-          expect(json_body['included'].length).to eq(1)
-          expect(json_body['included'].first["id"]).to eq(comments_policy_scope.first.id.to_s)
-        end
       end
     end
   end

--- a/spec/requests/resource_operations_spec.rb
+++ b/spec/requests/resource_operations_spec.rb
@@ -8,7 +8,8 @@ describe 'Resource operations', type: :request do
   let(:policy_scope) { Article.none }
 
   subject { last_response }
-  let(:json_data) { JSON.parse(last_response.body)["data"] }
+  let(:json_body) { JSON.parse(last_response.body) }
+  let(:json_data) { json_body["data"] }
 
   before do
     allow_any_instance_of(ArticlePolicy::Scope).to receive(:resolve).and_return(policy_scope)
@@ -35,6 +36,33 @@ describe 'Resource operations', type: :request do
       it 'returns results limited by policy scope' do
         expect(json_data.length).to eq(1)
         expect(json_data.first["id"]).to eq(article.id.to_s)
+      end
+    end
+
+    describe 'with ?include=comments' do
+      subject(:last_response) { get('/articles?include=comments') }
+      let(:chained_authorizer) { allow_operation('find', Article) }
+      let(:policy_scope) { Article.all }
+      let(:comments_policy_scope) { Comment.all }
+      before do
+        allow_any_instance_of(CommentPolicy::Scope).to receive(:resolve).and_return(comments_policy_scope)
+      end
+
+      context 'unauthorized for include_has_many_resource for Comment' do
+        before { disallow_operation('include_has_many_resource', Comment, authorizer: chained_authorizer) }
+        it { is_expected.to be_forbidden }
+      end
+
+      context 'authorized for include_has_many_resource for Comment' do
+        before { allow_operation('include_has_many_resource', Comment, authorizer: chained_authorizer) }
+        it { is_expected.to be_ok }
+
+        let(:comments_policy_scope) { Comment.limit(1) }
+
+        it 'includes only comments allowed by policy scope' do
+          expect(json_body['included'].length).to eq(1)
+          expect(json_body['included'].first["id"]).to eq(comments_policy_scope.first.id.to_s)
+        end
       end
     end
   end

--- a/spec/support/authorization_stubs.rb
+++ b/spec/support/authorization_stubs.rb
@@ -1,18 +1,18 @@
 module AuthorizationStubs
   AUTHORIZER_CLASS = JSONAPI::Authorization::DefaultPunditAuthorizer
 
-  def allow_operation(operation, *args)
-    authorizer = instance_double(AUTHORIZER_CLASS)
+  def allow_operation(operation, *args, authorizer: instance_double(AUTHORIZER_CLASS))
     allow(authorizer).to receive(operation).with(*args).and_return(nil)
 
     allow(AUTHORIZER_CLASS).to receive(:new).with(Hash).and_return(authorizer)
+    authorizer
   end
 
-  def disallow_operation(operation, *args)
-    authorizer = instance_double(AUTHORIZER_CLASS)
+  def disallow_operation(operation, *args, authorizer: instance_double(AUTHORIZER_CLASS))
     allow(authorizer).to receive(operation).with(*args).and_raise(Pundit::NotAuthorizedError)
 
     allow(AUTHORIZER_CLASS).to receive(:new).with(Hash).and_return(authorizer)
+    authorizer
   end
 
   def allow_operations(operation, operation_args)


### PR DESCRIPTION
Closes #7 

Logics to implement:

* [x] One-level deep `has_many` relationship (`?include=other-resources`) logic
* [x] One-level deep `has_one` relationship (`?include=another-resource`) logic
* [x] Multiple one-level relationships (`?include=other-resources,another-resource`) logic
* [x] Parse include directive graphs and authorize all relationships in the way (`?include=author.comments`)
* [x] Requests that have failed before authorization (e.g. due to validation errors) must not try to authorize include directives, too.
* [x] Add the source relation alongside the authorization checks

Attach those logics to all the end points which return records:

* [x] `GET /resources`
* [x] `GET /resources/1`
* [x] `PATCH /resources/1`
*  [x] `POST /resources`
* [x] `GET /resources/other-resources`
* [x] `GET /resources/another-resource`

Review notes:

* [x] Improve variable names in the operations processor recursive authorize method
* [x] Swap the authorizer method's argument order for consistency with other methods
* [ ] Don't use `public_send` on the model level as it bypasses restrictions imposed on the resource level
* [x] Simplify specs to just expect receiving `an_instance_of(Article)` style logic everywhere. It's not worth it to test for exact records, as we aren't able to do that on POST requests anyway.