### PR TITLE
Added ability to custom pundit_user

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,16 @@ JSONAPI::Authorization.configure do |config|
 end
 ```
 
+By default JSONAPI::Authorization uses the `:user` key from the JSONAPI context hash as the Pundit user. If you would like to use `:current_user` or some other key, it can be configured as well.
+
+```ruby
+JSONAPI::Authorization.configure do |config|
+  config.pundit_user = :current_user
+  # or a block can be provided
+  config.pundit_user = ->(context){ context[:current_user] }
+end
+```
+
 ## Troubleshooting
 
 ### "Unable to find policy" exception for a request

--- a/lib/jsonapi/authorization/configuration.rb
+++ b/lib/jsonapi/authorization/configuration.rb
@@ -4,9 +4,19 @@ module JSONAPI
   module Authorization
     class Configuration
       attr_accessor :authorizer
+      attr_accessor :pundit_user
 
       def initialize
-        self.authorizer = ::JSONAPI::Authorization::DefaultPunditAuthorizer
+        self.authorizer  = ::JSONAPI::Authorization::DefaultPunditAuthorizer
+        self.pundit_user = :user
+      end
+
+      def user_context(context)
+        if pundit_user.is_a?(Symbol)
+          context[pundit_user]
+        else
+          pundit_user.call(context)
+        end
       end
     end
 

--- a/lib/jsonapi/authorization/default_pundit_authorizer.rb
+++ b/lib/jsonapi/authorization/default_pundit_authorizer.rb
@@ -19,7 +19,7 @@ module JSONAPI
       #
       # * +context+ - The context passed down from the controller layer
       def initialize(context)
-        @user = context[:user]
+        @user = JSONAPI::Authorization.configuration.user_context(context)
       end
 
       # <tt>GET /resources</tt>

--- a/lib/jsonapi/authorization/pundit_scoped_resource.rb
+++ b/lib/jsonapi/authorization/pundit_scoped_resource.rb
@@ -7,7 +7,8 @@ module JSONAPI
 
       module ClassMethods
         def records(options = {})
-          ::Pundit.policy_scope!(options[:context][:user], _model_class)
+          user_context = JSONAPI::Authorization.configuration.user_context(options[:context])
+          ::Pundit.policy_scope!(user_context, _model_class)
         end
       end
 
@@ -19,7 +20,8 @@ module JSONAPI
         when JSONAPI::Relationship::ToOne
           record_or_records
         when JSONAPI::Relationship::ToMany
-          ::Pundit.policy_scope!(context[:user], record_or_records)
+          user_context = JSONAPI::Authorization.configuration.user_context(context)
+          ::Pundit.policy_scope!(user_context, record_or_records)
         else
           raise "Unknown relationship type #{relationship.inspect}"
         end

--- a/spec/dummy/config/application.rb
+++ b/spec/dummy/config/application.rb
@@ -22,7 +22,7 @@ class Application < Rails::Application
 
   config.middleware.delete "Rack::Lock"
   config.middleware.delete "ActionDispatch::Flash"
-  config.middleware.delete "ActionDispatch::BestStandardsSupport"
+  #config.middleware.delete "ActionDispatch::BestStandardsSupport"
 
   config.secret_key_base = "correct-horse-battery-staple"
 end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -25,8 +25,8 @@ ActiveRecord::Schema.define(version: 20160125083537) do
   end
 
   create_table "tags", force: :cascade do |t|
-    t.integer "taggable_id"
     t.string  "taggable_type"
+    t.integer "taggable_id"
   end
 
   create_table "users", force: :cascade do |t|

--- a/spec/jsonapi/authorization/configuration_spec.rb
+++ b/spec/jsonapi/authorization/configuration_spec.rb
@@ -1,0 +1,33 @@
+require 'spec_helper'
+RSpec.describe JSONAPI::Authorization::Configuration do
+  after do
+    # Set this back to the default after each
+    JSONAPI::Authorization.configuration.pundit_user = :user
+  end
+
+  describe '#user_context' do
+    context "given a symbol" do
+      it "returns the 'user'" do
+        JSONAPI::Authorization.configuration.pundit_user = :current_user
+
+        user = User.new
+        jsonapi_context = { current_user: user }
+        user_context = JSONAPI::Authorization.configuration.user_context(jsonapi_context)
+
+        expect(user_context).to be user
+      end
+    end
+
+    context "given a proc" do
+      it "returns the 'user'" do
+        JSONAPI::Authorization.configuration.pundit_user = ->(context){ context[:current_user] }
+
+        user = User.new
+        jsonapi_context = { current_user: user }
+        user_context = JSONAPI::Authorization.configuration.user_context(jsonapi_context)
+
+        expect(user_context).to be user        
+      end
+    end
+  end
+end


### PR DESCRIPTION
* Added tests
* Defaults to :user for backwards combat
* Can specify a symbol or a proc
* Updated README

```ruby
JSONAPI::Authorization.configure do |config|
  config.pundit_user = :current_user
  # or
  config.pundit_user = ->(context){ context[:current_user] }
  # or if you want the whole context available for pundit to use
  config.pundit_user = ->(context){ context }
end
```


