### PR TITLE
Add tests for every scenario of the relationship operations

### DIFF
--- a/spec/jsonapi/authorization/default_pundit_authorizer_spec.rb
+++ b/spec/jsonapi/authorization/default_pundit_authorizer_spec.rb
@@ -302,7 +302,7 @@ RSpec.describe JSONAPI::Authorization::DefaultPunditAuthorizer do
       it { is_expected.not_to raise_error }
     end
 
-    context 'unauthorized for update? on record' do
+    context 'unauthorized for replace_author? and update? on record' do
       before do
         stub_policy_actions(source_record, replace_author?: false, update?: false)
       end
@@ -345,7 +345,7 @@ RSpec.describe JSONAPI::Authorization::DefaultPunditAuthorizer do
       it { is_expected.not_to raise_error }
     end
 
-    context 'unauthorized for update? on record' do
+    context 'unauthorized for add_to_comments? and update? on record' do
       before do
         stub_policy_actions(source_record, add_to_comments?: false, update?: false)
       end
@@ -388,7 +388,7 @@ RSpec.describe JSONAPI::Authorization::DefaultPunditAuthorizer do
       it { is_expected.not_to raise_error }
     end
 
-    context 'unauthorized for update? on record' do
+    context 'unauthorized for update? and replace_comments? on record' do
       before do
         stub_policy_actions(article, replace_comments?: false, update?: false)
       end
@@ -431,7 +431,7 @@ RSpec.describe JSONAPI::Authorization::DefaultPunditAuthorizer do
       it { is_expected.not_to raise_error }
     end
 
-    context 'unauthorized for update? on article' do
+    context 'unauthorized for update? and remove_from_comments? on article' do
       before do
         stub_policy_actions(article, remove_from_comments?: false, update?: false)
       end
@@ -472,7 +472,7 @@ RSpec.describe JSONAPI::Authorization::DefaultPunditAuthorizer do
       it { is_expected.not_to raise_error }
     end
 
-    context 'unauthorized for update? on record' do
+    context 'unauthorized for update? and remove_author? on record' do
       before do
         stub_policy_actions(source_record, remove_author?: false, update?: false)
       end

--- a/spec/jsonapi/authorization/default_pundit_authorizer_spec.rb
+++ b/spec/jsonapi/authorization/default_pundit_authorizer_spec.rb
@@ -388,7 +388,7 @@ RSpec.describe JSONAPI::Authorization::DefaultPunditAuthorizer do
       it { is_expected.not_to raise_error }
     end
 
-    context 'unauthorized for update? and replace_comments? on record' do
+    context 'unauthorized for replace_comments? and update? on record' do
       before do
         stub_policy_actions(article, replace_comments?: false, update?: false)
       end
@@ -431,7 +431,7 @@ RSpec.describe JSONAPI::Authorization::DefaultPunditAuthorizer do
       it { is_expected.not_to raise_error }
     end
 
-    context 'unauthorized for update? and remove_from_comments? on article' do
+    context 'unauthorized for remove_from_comments? and update? on article' do
       before do
         stub_policy_actions(article, remove_from_comments?: false, update?: false)
       end
@@ -472,7 +472,7 @@ RSpec.describe JSONAPI::Authorization::DefaultPunditAuthorizer do
       it { is_expected.not_to raise_error }
     end
 
-    context 'unauthorized for update? and remove_author? on record' do
+    context 'unauthorized for remove_author? and update? on record' do
       before do
         stub_policy_actions(source_record, remove_author?: false, update?: false)
       end

--- a/spec/jsonapi/authorization/default_pundit_authorizer_spec.rb
+++ b/spec/jsonapi/authorization/default_pundit_authorizer_spec.rb
@@ -304,8 +304,7 @@ RSpec.describe JSONAPI::Authorization::DefaultPunditAuthorizer do
 
     context 'unauthorized for update? on record' do
       before do
-        disallow_action(source_record, 'replace_author?')
-        disallow_action(source_record, 'update?')
+        stub_policy_actions(source_record, replace_author?: false, update?: false)
       end
       it { is_expected.to raise_error(::Pundit::NotAuthorizedError) }
     end
@@ -348,8 +347,7 @@ RSpec.describe JSONAPI::Authorization::DefaultPunditAuthorizer do
 
     context 'unauthorized for update? on record' do
       before do
-        disallow_action(source_record, 'add_to_comments?')
-        disallow_action(source_record, 'update?')
+        stub_policy_actions(source_record, add_to_comments?: false, update?: false)
       end
       it { is_expected.to raise_error(::Pundit::NotAuthorizedError) }
     end
@@ -392,8 +390,7 @@ RSpec.describe JSONAPI::Authorization::DefaultPunditAuthorizer do
 
     context 'unauthorized for update? on record' do
       before do
-        disallow_action(article, 'replace_comments?')
-        disallow_action(article, 'update?')
+        stub_policy_actions(article, replace_comments?: false, update?: false)
       end
       it { is_expected.to raise_error(::Pundit::NotAuthorizedError) }
     end
@@ -436,8 +433,7 @@ RSpec.describe JSONAPI::Authorization::DefaultPunditAuthorizer do
 
     context 'unauthorized for update? on article' do
       before do
-        disallow_action(article, 'remove_from_comments?')
-        disallow_action(article, 'update?')
+        stub_policy_actions(article, remove_from_comments?: false, update?: false)
       end
       it { is_expected.to raise_error(::Pundit::NotAuthorizedError) }
     end
@@ -478,8 +474,7 @@ RSpec.describe JSONAPI::Authorization::DefaultPunditAuthorizer do
 
     context 'unauthorized for update? on record' do
       before do
-        disallow_action(source_record, 'remove_author?')
-        disallow_action(source_record, 'update?')
+        stub_policy_actions(source_record, remove_author?: false, update?: false)
       end
       it { is_expected.to raise_error(::Pundit::NotAuthorizedError) }
     end

--- a/spec/jsonapi/authorization/default_pundit_authorizer_spec.rb
+++ b/spec/jsonapi/authorization/default_pundit_authorizer_spec.rb
@@ -302,6 +302,20 @@ RSpec.describe JSONAPI::Authorization::DefaultPunditAuthorizer do
       it { is_expected.not_to raise_error }
     end
 
+    context 'unauthorized for replace_author? and authorized for update? on record' do
+      before do
+        stub_policy_actions(source_record, replace_author?: false, update?: true)
+      end
+      it { is_expected.to raise_error(::Pundit::NotAuthorizedError) }
+    end
+
+    context 'authorized for replace_author? and unauthorized for update? on record' do
+      before do
+        stub_policy_actions(source_record, replace_author?: true, update?: false)
+      end
+      it { is_expected.not_to raise_error }
+    end
+
     context 'unauthorized for replace_author? and update? on record' do
       before do
         stub_policy_actions(source_record, replace_author?: false, update?: false)
@@ -342,6 +356,20 @@ RSpec.describe JSONAPI::Authorization::DefaultPunditAuthorizer do
 
     context 'authorized for update? on record' do
       before { allow_action(source_record, 'update?') }
+      it { is_expected.not_to raise_error }
+    end
+
+    context 'unauthorized for add_to_comments? and authorized for update? on record' do
+      before do
+        stub_policy_actions(source_record, add_to_comments?: false, update?: true)
+      end
+      it { is_expected.to raise_error(::Pundit::NotAuthorizedError) }
+    end
+
+    context 'authorized for add_to_comments? and unauthorized for update? on record' do
+      before do
+        stub_policy_actions(source_record, add_to_comments?: true, update?: false)
+      end
       it { is_expected.not_to raise_error }
     end
 
@@ -388,6 +416,20 @@ RSpec.describe JSONAPI::Authorization::DefaultPunditAuthorizer do
       it { is_expected.not_to raise_error }
     end
 
+    context 'unauthorized for replace_comments? and authorized for update? on record' do
+      before do
+        stub_policy_actions(article, replace_comments?: false, update?: true)
+      end
+      it { is_expected.to raise_error(::Pundit::NotAuthorizedError) }
+    end
+
+    context 'authorized for replace_comments? and unauthorized for update? on record' do
+      before do
+        stub_policy_actions(article, replace_comments?: true, update?: false)
+      end
+      it { is_expected.not_to raise_error }
+    end
+
     context 'unauthorized for replace_comments? and update? on record' do
       before do
         stub_policy_actions(article, replace_comments?: false, update?: false)
@@ -431,6 +473,20 @@ RSpec.describe JSONAPI::Authorization::DefaultPunditAuthorizer do
       it { is_expected.not_to raise_error }
     end
 
+    context 'unauthorized for remove_from_comments? and authorized for update? on article' do
+      before do
+        stub_policy_actions(article, remove_from_comments?: false, update?: true)
+      end
+      it { is_expected.to raise_error(::Pundit::NotAuthorizedError) }
+    end
+
+    context 'authorized for remove_from_comments? and unauthorized for update? on article' do
+      before do
+        stub_policy_actions(article, remove_from_comments?: true, update?: false)
+      end
+      it { is_expected.not_to raise_error }
+    end
+
     context 'unauthorized for remove_from_comments? and update? on article' do
       before do
         stub_policy_actions(article, remove_from_comments?: false, update?: false)
@@ -469,6 +525,20 @@ RSpec.describe JSONAPI::Authorization::DefaultPunditAuthorizer do
 
     context 'authorized for update? on record' do
       before { allow_action(source_record, 'update?') }
+      it { is_expected.not_to raise_error }
+    end
+
+    context 'unauthorized for remove_author? and authorized for update? on record' do
+      before do
+        stub_policy_actions(source_record, remove_author?: false, update?: true)
+      end
+      it { is_expected.to raise_error(::Pundit::NotAuthorizedError) }
+    end
+
+    context 'authorized for remove_author? and unauthorized for update? on record' do
+      before do
+        stub_policy_actions(source_record, remove_author?: true, update?: false)
+      end
       it { is_expected.not_to raise_error }
     end
 

--- a/spec/jsonapi/authorization/default_pundit_authorizer_spec.rb
+++ b/spec/jsonapi/authorization/default_pundit_authorizer_spec.rb
@@ -303,23 +303,17 @@ RSpec.describe JSONAPI::Authorization::DefaultPunditAuthorizer do
     end
 
     context 'unauthorized for replace_author? and authorized for update? on record' do
-      before do
-        stub_policy_actions(source_record, replace_author?: false, update?: true)
-      end
+      before { stub_policy_actions(source_record, replace_author?: false, update?: true) }
       it { is_expected.to raise_error(::Pundit::NotAuthorizedError) }
     end
 
     context 'authorized for replace_author? and unauthorized for update? on record' do
-      before do
-        stub_policy_actions(source_record, replace_author?: true, update?: false)
-      end
+      before { stub_policy_actions(source_record, replace_author?: true, update?: false) }
       it { is_expected.not_to raise_error }
     end
 
     context 'unauthorized for replace_author? and update? on record' do
-      before do
-        stub_policy_actions(source_record, replace_author?: false, update?: false)
-      end
+      before { stub_policy_actions(source_record, replace_author?: false, update?: false) }
       it { is_expected.to raise_error(::Pundit::NotAuthorizedError) }
     end
 
@@ -360,23 +354,17 @@ RSpec.describe JSONAPI::Authorization::DefaultPunditAuthorizer do
     end
 
     context 'unauthorized for add_to_comments? and authorized for update? on record' do
-      before do
-        stub_policy_actions(source_record, add_to_comments?: false, update?: true)
-      end
+      before { stub_policy_actions(source_record, add_to_comments?: false, update?: true) }
       it { is_expected.to raise_error(::Pundit::NotAuthorizedError) }
     end
 
     context 'authorized for add_to_comments? and unauthorized for update? on record' do
-      before do
-        stub_policy_actions(source_record, add_to_comments?: true, update?: false)
-      end
+      before { stub_policy_actions(source_record, add_to_comments?: true, update?: false) }
       it { is_expected.not_to raise_error }
     end
 
     context 'unauthorized for add_to_comments? and update? on record' do
-      before do
-        stub_policy_actions(source_record, add_to_comments?: false, update?: false)
-      end
+      before { stub_policy_actions(source_record, add_to_comments?: false, update?: false) }
       it { is_expected.to raise_error(::Pundit::NotAuthorizedError) }
     end
 
@@ -417,23 +405,17 @@ RSpec.describe JSONAPI::Authorization::DefaultPunditAuthorizer do
     end
 
     context 'unauthorized for replace_comments? and authorized for update? on record' do
-      before do
-        stub_policy_actions(article, replace_comments?: false, update?: true)
-      end
+      before { stub_policy_actions(article, replace_comments?: false, update?: true) }
       it { is_expected.to raise_error(::Pundit::NotAuthorizedError) }
     end
 
     context 'authorized for replace_comments? and unauthorized for update? on record' do
-      before do
-        stub_policy_actions(article, replace_comments?: true, update?: false)
-      end
+      before { stub_policy_actions(article, replace_comments?: true, update?: false) }
       it { is_expected.not_to raise_error }
     end
 
     context 'unauthorized for replace_comments? and update? on record' do
-      before do
-        stub_policy_actions(article, replace_comments?: false, update?: false)
-      end
+      before { stub_policy_actions(article, replace_comments?: false, update?: false) }
       it { is_expected.to raise_error(::Pundit::NotAuthorizedError) }
     end
 
@@ -474,23 +456,17 @@ RSpec.describe JSONAPI::Authorization::DefaultPunditAuthorizer do
     end
 
     context 'unauthorized for remove_from_comments? and authorized for update? on article' do
-      before do
-        stub_policy_actions(article, remove_from_comments?: false, update?: true)
-      end
+      before { stub_policy_actions(article, remove_from_comments?: false, update?: true) }
       it { is_expected.to raise_error(::Pundit::NotAuthorizedError) }
     end
 
     context 'authorized for remove_from_comments? and unauthorized for update? on article' do
-      before do
-        stub_policy_actions(article, remove_from_comments?: true, update?: false)
-      end
+      before { stub_policy_actions(article, remove_from_comments?: true, update?: false) }
       it { is_expected.not_to raise_error }
     end
 
     context 'unauthorized for remove_from_comments? and update? on article' do
-      before do
-        stub_policy_actions(article, remove_from_comments?: false, update?: false)
-      end
+      before { stub_policy_actions(article, remove_from_comments?: false, update?: false) }
       it { is_expected.to raise_error(::Pundit::NotAuthorizedError) }
     end
 
@@ -529,23 +505,17 @@ RSpec.describe JSONAPI::Authorization::DefaultPunditAuthorizer do
     end
 
     context 'unauthorized for remove_author? and authorized for update? on record' do
-      before do
-        stub_policy_actions(source_record, remove_author?: false, update?: true)
-      end
+      before { stub_policy_actions(source_record, remove_author?: false, update?: true) }
       it { is_expected.to raise_error(::Pundit::NotAuthorizedError) }
     end
 
     context 'authorized for remove_author? and unauthorized for update? on record' do
-      before do
-        stub_policy_actions(source_record, remove_author?: true, update?: false)
-      end
+      before { stub_policy_actions(source_record, remove_author?: true, update?: false) }
       it { is_expected.not_to raise_error }
     end
 
     context 'unauthorized for remove_author? and update? on record' do
-      before do
-        stub_policy_actions(source_record, remove_author?: false, update?: false)
-      end
+      before { stub_policy_actions(source_record, remove_author?: false, update?: false) }
       it { is_expected.to raise_error(::Pundit::NotAuthorizedError) }
     end
 

--- a/spec/jsonapi/authorization/default_pundit_authorizer_spec.rb
+++ b/spec/jsonapi/authorization/default_pundit_authorizer_spec.rb
@@ -13,12 +13,12 @@ RSpec.describe JSONAPI::Authorization::DefaultPunditAuthorizer do
     end
 
     context 'authorized for index? on record' do
-      before { allow_action('index?', source_record) }
+      before { allow_action(source_record, 'index?') }
       it { is_expected.not_to raise_error }
     end
 
     context 'unauthorized for index? on record' do
-      before { disallow_action('index?', source_record) }
+      before { disallow_action(source_record, 'index?') }
       it { is_expected.to raise_error(::Pundit::NotAuthorizedError) }
     end
   end
@@ -29,12 +29,12 @@ RSpec.describe JSONAPI::Authorization::DefaultPunditAuthorizer do
     end
 
     context 'authorized for show? on record' do
-      before { allow_action('show?', source_record) }
+      before { allow_action(source_record, 'show?') }
       it { is_expected.not_to raise_error }
     end
 
     context 'unauthorized for show? on record' do
-      before { disallow_action('show?', source_record) }
+      before { disallow_action(source_record, 'show?') }
       it { is_expected.to raise_error(::Pundit::NotAuthorizedError) }
     end
   end
@@ -45,18 +45,18 @@ RSpec.describe JSONAPI::Authorization::DefaultPunditAuthorizer do
     end
 
     context 'authorized for show? on source record' do
-      before { allow_action('show?', source_record) }
+      before { allow_action(source_record, 'show?') }
 
       context 'related record is present' do
         let(:related_record) { Comment.new }
 
         context 'authorized for show on related record' do
-          before { allow_action('show?', related_record) }
+          before { allow_action(related_record, 'show?') }
           it { is_expected.not_to raise_error }
         end
 
         context 'unauthorized for show on related record' do
-          before { disallow_action('show?', related_record) }
+          before { disallow_action(related_record, 'show?') }
           it { is_expected.to raise_error(::Pundit::NotAuthorizedError) }
         end
       end
@@ -68,18 +68,18 @@ RSpec.describe JSONAPI::Authorization::DefaultPunditAuthorizer do
     end
 
     context 'unauthorized for show? on source record' do
-      before { disallow_action('show?', source_record) }
+      before { disallow_action(source_record, 'show?') }
 
       context 'related record is present' do
         let(:related_record) { Comment.new }
 
         context 'authorized for show on related record' do
-          before { allow_action('show?', related_record) }
+          before { allow_action(related_record, 'show?') }
           it { is_expected.to raise_error(::Pundit::NotAuthorizedError) }
         end
 
         context 'unauthorized for show on related record' do
-          before { disallow_action('show?', related_record) }
+          before { disallow_action(related_record, 'show?') }
           it { is_expected.to raise_error(::Pundit::NotAuthorizedError) }
         end
       end
@@ -97,18 +97,18 @@ RSpec.describe JSONAPI::Authorization::DefaultPunditAuthorizer do
     end
 
     context 'authorized for show? on source record' do
-      before { allow_action('show?', source_record) }
+      before { allow_action(source_record, 'show?') }
 
       context 'related record is present' do
         let(:related_record) { Comment.new }
 
         context 'authorized for show on related record' do
-          before { allow_action('show?', related_record) }
+          before { allow_action(related_record, 'show?') }
           it { is_expected.not_to raise_error }
         end
 
         context 'unauthorized for show on related record' do
-          before { disallow_action('show?', related_record) }
+          before { disallow_action(related_record, 'show?') }
           it { is_expected.to raise_error(::Pundit::NotAuthorizedError) }
         end
       end
@@ -120,18 +120,18 @@ RSpec.describe JSONAPI::Authorization::DefaultPunditAuthorizer do
     end
 
     context 'unauthorized for show? on source record' do
-      before { disallow_action('show?', source_record) }
+      before { disallow_action(source_record, 'show?') }
 
       context 'related record is present' do
         let(:related_record) { Comment.new }
 
         context 'authorized for show on related record' do
-          before { allow_action('show?', related_record) }
+          before { allow_action(related_record, 'show?') }
           it { is_expected.to raise_error(::Pundit::NotAuthorizedError) }
         end
 
         context 'unauthorized for show on related record' do
-          before { disallow_action('show?', related_record) }
+          before { disallow_action(related_record, 'show?') }
           it { is_expected.to raise_error(::Pundit::NotAuthorizedError) }
         end
       end
@@ -149,12 +149,12 @@ RSpec.describe JSONAPI::Authorization::DefaultPunditAuthorizer do
     end
 
     context 'authorized for show? on record' do
-      before { allow_action('show?', source_record) }
+      before { allow_action(source_record, 'show?') }
       it { is_expected.not_to raise_error }
     end
 
     context 'unauthorized for show? on record' do
-      before { disallow_action('show?', source_record) }
+      before { disallow_action(source_record, 'show?') }
       it { is_expected.to raise_error(::Pundit::NotAuthorizedError) }
     end
   end
@@ -166,7 +166,7 @@ RSpec.describe JSONAPI::Authorization::DefaultPunditAuthorizer do
     end
 
     context 'authorized for update? on source record' do
-      before { allow_action('update?', source_record) }
+      before { allow_action(source_record, 'update?') }
 
       context 'related records is empty' do
         let(:related_records) { [] }
@@ -174,15 +174,15 @@ RSpec.describe JSONAPI::Authorization::DefaultPunditAuthorizer do
       end
 
       context 'authorized for update? on all of the related records' do
-        before { related_records.each { |r| allow_action('update?', r) } }
+        before { related_records.each { |r| allow_action(r, 'update?') } }
         it { is_expected.not_to raise_error }
       end
 
       context 'unauthorized for update? on any of the related records' do
         let(:related_records) { [Comment.new(id: 1), Comment.new(id: 2)] }
         before do
-          allow_action('update?', related_records.first)
-          disallow_action('update?', related_records.last)
+          allow_action(related_records.first, 'update?')
+          disallow_action(related_records.last, 'update?')
         end
 
         it { is_expected.to raise_error(::Pundit::NotAuthorizedError) }
@@ -190,7 +190,7 @@ RSpec.describe JSONAPI::Authorization::DefaultPunditAuthorizer do
     end
 
     context 'unauthorized for update? on source record' do
-      before { disallow_action('update?', source_record) }
+      before { disallow_action(source_record, 'update?') }
 
       context 'related records is empty' do
         let(:related_records) { [] }
@@ -198,15 +198,15 @@ RSpec.describe JSONAPI::Authorization::DefaultPunditAuthorizer do
       end
 
       context 'authorized for update? on all of the related records' do
-        before { related_records.each { |r| allow_action('update?', r) } }
+        before { related_records.each { |r| allow_action(r, 'update?') } }
         it { is_expected.to raise_error(::Pundit::NotAuthorizedError) }
       end
 
       context 'unauthorized for update? on any of the related records' do
         let(:related_records) { [Comment.new(id: 1), Comment.new(id: 2)] }
         before do
-          allow_action('update?', related_records.first)
-          disallow_action('update?', related_records.last)
+          allow_action(related_records.first, 'update?')
+          disallow_action(related_records.last, 'update?')
         end
 
         it { is_expected.to raise_error(::Pundit::NotAuthorizedError) }
@@ -222,7 +222,7 @@ RSpec.describe JSONAPI::Authorization::DefaultPunditAuthorizer do
     end
 
     context 'authorized for create? on source class' do
-      before { allow_action('create?', source_class) }
+      before { allow_action(source_class, 'create?') }
 
       context 'related records is empty' do
         let(:related_records) { [] }
@@ -230,15 +230,15 @@ RSpec.describe JSONAPI::Authorization::DefaultPunditAuthorizer do
       end
 
       context 'authorized for update? on all of the related records' do
-        before { related_records.each { |r| allow_action('update?', r) } }
+        before { related_records.each { |r| allow_action(r, 'update?') } }
         it { is_expected.not_to raise_error }
       end
 
       context 'unauthorized for update? on any of the related records' do
         let(:related_records) { [Comment.new(id: 1), Comment.new(id: 2)] }
         before do
-          allow_action('update?', related_records.first)
-          disallow_action('update?', related_records.last)
+          allow_action(related_records.first, 'update?')
+          disallow_action(related_records.last, 'update?')
         end
 
         it { is_expected.to raise_error(::Pundit::NotAuthorizedError) }
@@ -246,7 +246,7 @@ RSpec.describe JSONAPI::Authorization::DefaultPunditAuthorizer do
     end
 
     context 'unauthorized for create? on source class' do
-      before { disallow_action('create?', source_class) }
+      before { disallow_action(source_class, 'create?') }
 
       context 'related records is empty' do
         let(:related_records) { [] }
@@ -254,15 +254,15 @@ RSpec.describe JSONAPI::Authorization::DefaultPunditAuthorizer do
       end
 
       context 'authorized for update? on all of the related records' do
-        before { related_records.each { |r| allow_action('update?', r) } }
+        before { related_records.each { |r| allow_action(r, 'update?') } }
         it { is_expected.to raise_error(::Pundit::NotAuthorizedError) }
       end
 
       context 'unauthorized for update? on any of the related records' do
         let(:related_records) { [Comment.new(id: 1), Comment.new(id: 2)] }
         before do
-          allow_action('update?', related_records.first)
-          disallow_action('update?', related_records.last)
+          allow_action(related_records.first, 'update?')
+          disallow_action(related_records.last, 'update?')
         end
 
         it { is_expected.to raise_error(::Pundit::NotAuthorizedError) }
@@ -276,12 +276,12 @@ RSpec.describe JSONAPI::Authorization::DefaultPunditAuthorizer do
     end
 
     context 'authorized for destroy? on record' do
-      before { allow_action('destroy?', source_record) }
+      before { allow_action(source_record, 'destroy?') }
       it { is_expected.not_to raise_error }
     end
 
     context 'unauthorized for destroy? on record' do
-      before { disallow_action('destroy?', source_record) }
+      before { disallow_action(source_record, 'destroy?') }
       it { is_expected.to raise_error(::Pundit::NotAuthorizedError) }
     end
   end
@@ -293,19 +293,19 @@ RSpec.describe JSONAPI::Authorization::DefaultPunditAuthorizer do
     end
 
     context 'authorized for replace_author? on record' do
-      before { allow_action('replace_author?', source_record) }
+      before { allow_action(source_record, 'replace_author?') }
       it { is_expected.not_to raise_error }
     end
 
     context 'authorized for update? on record' do
-      before { allow_action('update?', source_record) }
+      before { allow_action(source_record, 'update?') }
       it { is_expected.not_to raise_error }
     end
 
     context 'unauthorized for update? on record' do
       before do
-        disallow_action('replace_author?', source_record)
-        disallow_action('update?', source_record)
+        disallow_action(source_record, 'replace_author?')
+        disallow_action(source_record, 'update?')
       end
       it { is_expected.to raise_error(::Pundit::NotAuthorizedError) }
     end
@@ -319,12 +319,12 @@ RSpec.describe JSONAPI::Authorization::DefaultPunditAuthorizer do
       end
 
       context 'authorized for update? on record' do
-        before { allow_action('update?', source_record) }
+        before { allow_action(source_record, 'update?') }
         it { is_expected.not_to raise_error }
       end
 
       context 'unauthorized for update? on record' do
-        before { disallow_action('update?', source_record) }
+        before { disallow_action(source_record, 'update?') }
         it { is_expected.to raise_error(::Pundit::NotAuthorizedError) }
       end
     end
@@ -337,19 +337,19 @@ RSpec.describe JSONAPI::Authorization::DefaultPunditAuthorizer do
     end
 
     context 'authorized for add_to_comments? on record' do
-      before { allow_action('add_to_comments?', source_record) }
+      before { allow_action(source_record, 'add_to_comments?') }
       it { is_expected.not_to raise_error }
     end
 
     context 'authorized for update? on record' do
-      before { allow_action('update?', source_record) }
+      before { allow_action(source_record, 'update?') }
       it { is_expected.not_to raise_error }
     end
 
     context 'unauthorized for update? on record' do
       before do
-        disallow_action('add_to_comments?', source_record)
-        disallow_action('update?', source_record)
+        disallow_action(source_record, 'add_to_comments?')
+        disallow_action(source_record, 'update?')
       end
       it { is_expected.to raise_error(::Pundit::NotAuthorizedError) }
     end
@@ -362,12 +362,12 @@ RSpec.describe JSONAPI::Authorization::DefaultPunditAuthorizer do
       end
 
       context 'authorized for update? on record' do
-        before { allow_action('update?', source_record) }
+        before { allow_action(source_record, 'update?') }
         it { is_expected.not_to raise_error }
       end
 
       context 'unauthorized for update? on record' do
-        before { disallow_action('update?', source_record) }
+        before { disallow_action(source_record, 'update?') }
         it { is_expected.to raise_error(::Pundit::NotAuthorizedError) }
       end
     end
@@ -381,19 +381,19 @@ RSpec.describe JSONAPI::Authorization::DefaultPunditAuthorizer do
     end
 
     context 'authorized for replace_comments? on record' do
-      before { allow_action('replace_comments?', article) }
+      before { allow_action(article, 'replace_comments?') }
       it { is_expected.not_to raise_error }
     end
 
     context 'authorized for update? on record' do
-      before { allow_action('update?', article) }
+      before { allow_action(article, 'update?') }
       it { is_expected.not_to raise_error }
     end
 
     context 'unauthorized for update? on record' do
       before do
-        disallow_action('replace_comments?', article)
-        disallow_action('update?', article)
+        disallow_action(article, 'replace_comments?')
+        disallow_action(article, 'update?')
       end
       it { is_expected.to raise_error(::Pundit::NotAuthorizedError) }
     end
@@ -406,12 +406,12 @@ RSpec.describe JSONAPI::Authorization::DefaultPunditAuthorizer do
       end
 
       context 'authorized for update? on record' do
-        before { allow_action('update?', article) }
+        before { allow_action(article, 'update?') }
         it { is_expected.not_to raise_error }
       end
 
       context 'unauthorized for update? on record' do
-        before { disallow_action('update?', article) }
+        before { disallow_action(article, 'update?') }
         it { is_expected.to raise_error(::Pundit::NotAuthorizedError) }
       end
     end
@@ -425,19 +425,19 @@ RSpec.describe JSONAPI::Authorization::DefaultPunditAuthorizer do
     end
 
     context 'authorized for remove_from_comments? on article' do
-      before { allow_action('remove_from_comments?', article) }
+      before { allow_action(article, 'remove_from_comments?') }
       it { is_expected.not_to raise_error }
     end
 
     context 'authorized for update? on article' do
-      before { allow_action('update?', article) }
+      before { allow_action(article, 'update?') }
       it { is_expected.not_to raise_error }
     end
 
     context 'unauthorized for update? on article' do
       before do
-        disallow_action('remove_from_comments?', article)
-        disallow_action('update?', article)
+        disallow_action(article, 'remove_from_comments?')
+        disallow_action(article, 'update?')
       end
       it { is_expected.to raise_error(::Pundit::NotAuthorizedError) }
     end
@@ -450,12 +450,12 @@ RSpec.describe JSONAPI::Authorization::DefaultPunditAuthorizer do
       end
 
       context 'authorized for update? on article' do
-        before { allow_action('update?', article) }
+        before { allow_action(article, 'update?') }
         it { is_expected.not_to raise_error }
       end
 
       context 'unauthorized for update? on article' do
-        before { disallow_action('update?', article) }
+        before { disallow_action(article, 'update?') }
         it { is_expected.to raise_error(::Pundit::NotAuthorizedError) }
       end
     end
@@ -467,19 +467,19 @@ RSpec.describe JSONAPI::Authorization::DefaultPunditAuthorizer do
     end
 
     context 'authorized for remove_author? on record' do
-      before { allow_action('remove_author?', source_record) }
+      before { allow_action(source_record, 'remove_author?') }
       it { is_expected.not_to raise_error }
     end
 
     context 'authorized for update? on record' do
-      before { allow_action('update?', source_record) }
+      before { allow_action(source_record, 'update?') }
       it { is_expected.not_to raise_error }
     end
 
     context 'unauthorized for update? on record' do
       before do
-        disallow_action('remove_author?', source_record)
-        disallow_action('update?', source_record)
+        disallow_action(source_record, 'remove_author?')
+        disallow_action(source_record, 'update?')
       end
       it { is_expected.to raise_error(::Pundit::NotAuthorizedError) }
     end
@@ -492,12 +492,12 @@ RSpec.describe JSONAPI::Authorization::DefaultPunditAuthorizer do
       end
 
       context 'authorized for update? on record' do
-        before { allow_action('update?', source_record) }
+        before { allow_action(source_record, 'update?') }
         it { is_expected.not_to raise_error }
       end
 
       context 'unauthorized for update? on record' do
-        before { disallow_action('update?', source_record) }
+        before { disallow_action(source_record, 'update?') }
         it { is_expected.to raise_error(::Pundit::NotAuthorizedError) }
       end
     end
@@ -511,12 +511,12 @@ RSpec.describe JSONAPI::Authorization::DefaultPunditAuthorizer do
     end
 
     context 'authorized for index? on record class' do
-      before { allow_action('index?', record_class) }
+      before { allow_action(record_class, 'index?') }
       it { is_expected.not_to raise_error }
     end
 
     context 'unauthorized for index? on record class' do
-      before { disallow_action('index?', record_class) }
+      before { disallow_action(record_class, 'index?') }
       it { is_expected.to raise_error(::Pundit::NotAuthorizedError) }
     end
   end
@@ -529,12 +529,12 @@ RSpec.describe JSONAPI::Authorization::DefaultPunditAuthorizer do
     end
 
     context 'authorized for show? on record' do
-      before { allow_action('show?', related_record) }
+      before { allow_action(related_record, 'show?') }
       it { is_expected.not_to raise_error }
     end
 
     context 'unauthorized for show? on record' do
-      before { disallow_action('show?', related_record) }
+      before { disallow_action(related_record, 'show?') }
       it { is_expected.to raise_error(::Pundit::NotAuthorizedError) }
     end
   end

--- a/spec/jsonapi/authorization/default_pundit_authorizer_spec.rb
+++ b/spec/jsonapi/authorization/default_pundit_authorizer_spec.rb
@@ -292,13 +292,8 @@ RSpec.describe JSONAPI::Authorization::DefaultPunditAuthorizer do
       -> { authorizer.replace_to_one_relationship(source_record, related_record, :author) }
     end
 
-    context 'authorized for replace_author? on record' do
-      before { allow_action(source_record, 'replace_author?') }
-      it { is_expected.not_to raise_error }
-    end
-
-    context 'authorized for update? on record' do
-      before { allow_action(source_record, 'update?') }
+    context 'authorized for replace_author? and update? on record' do
+      before { stub_policy_actions(source_record, replace_author?: true, update?: true) }
       it { is_expected.not_to raise_error }
     end
 
@@ -343,13 +338,8 @@ RSpec.describe JSONAPI::Authorization::DefaultPunditAuthorizer do
       -> { authorizer.create_to_many_relationship(source_record, related_records, :comments) }
     end
 
-    context 'authorized for add_to_comments? on record' do
-      before { allow_action(source_record, 'add_to_comments?') }
-      it { is_expected.not_to raise_error }
-    end
-
-    context 'authorized for update? on record' do
-      before { allow_action(source_record, 'update?') }
+    context 'authorized for add_to_comments? and update? on record' do
+      before { stub_policy_actions(source_record, add_to_comments?: true, update?: true) }
       it { is_expected.not_to raise_error }
     end
 
@@ -394,13 +384,8 @@ RSpec.describe JSONAPI::Authorization::DefaultPunditAuthorizer do
       -> { authorizer.replace_to_many_relationship(article, new_comments, :comments) }
     end
 
-    context 'authorized for replace_comments? on record' do
-      before { allow_action(article, 'replace_comments?') }
-      it { is_expected.not_to raise_error }
-    end
-
-    context 'authorized for update? on record' do
-      before { allow_action(article, 'update?') }
+    context 'authorized for replace_comments? and update? on record' do
+      before { stub_policy_actions(article, replace_comments?: true, update?: true) }
       it { is_expected.not_to raise_error }
     end
 
@@ -445,13 +430,8 @@ RSpec.describe JSONAPI::Authorization::DefaultPunditAuthorizer do
       -> { authorizer.remove_to_many_relationship(article, comments_to_remove, :comments) }
     end
 
-    context 'authorized for remove_from_comments? on article' do
-      before { allow_action(article, 'remove_from_comments?') }
-      it { is_expected.not_to raise_error }
-    end
-
-    context 'authorized for update? on article' do
-      before { allow_action(article, 'update?') }
+    context 'authorized for remove_from_comments? and article? on article' do
+      before { stub_policy_actions(article, remove_from_comments?: true, update?: true) }
       it { is_expected.not_to raise_error }
     end
 
@@ -494,13 +474,8 @@ RSpec.describe JSONAPI::Authorization::DefaultPunditAuthorizer do
       -> { authorizer.remove_to_one_relationship(source_record, :author) }
     end
 
-    context 'authorized for remove_author? on record' do
-      before { allow_action(source_record, 'remove_author?') }
-      it { is_expected.not_to raise_error }
-    end
-
-    context 'authorized for update? on record' do
-      before { allow_action(source_record, 'update?') }
+    context 'authorized for remove_author? and article? on record' do
+      before { stub_policy_actions(source_record, remove_author?: true, update?: true) }
       it { is_expected.not_to raise_error }
     end
 

--- a/spec/support/pundit_stubs.rb
+++ b/spec/support/pundit_stubs.rb
@@ -1,12 +1,12 @@
 module PunditStubs
-  def allow_action(action, record)
+  def allow_action(record, action)
     policy = ::Pundit::PolicyFinder.new(record).policy
     allow(policy).to(
       receive(:new).with(any_args, record) { instance_double(policy, action => true) }
     )
   end
 
-  def disallow_action(action, record)
+  def disallow_action(record, action)
     policy = ::Pundit::PolicyFinder.new(record).policy
     allow(policy).to(
       receive(:new).with(any_args, record) { instance_double(policy, action => false) }

--- a/spec/support/pundit_stubs.rb
+++ b/spec/support/pundit_stubs.rb
@@ -12,4 +12,17 @@ module PunditStubs
       receive(:new).with(any_args, record) { instance_double(policy, action => false) }
     )
   end
+
+  def stub_policy_actions(record, actions_and_return_values)
+    policy = ::Pundit::PolicyFinder.new(record).policy
+    allow(policy).to(
+      receive(:new).with(any_args, record) do
+        instance_double(policy).tap do |policy_double|
+          actions_and_return_values.each do |action, is_allowed|
+            allow(policy_double).to receive(action).and_return(is_allowed)
+          end
+        end
+      end
+    )
+  end
 end


### PR DESCRIPTION
We want to make sure the tests for the new cases match all the possible cases:
  * authorized with finer grained policy but NOT authorized with `update?`
  * NOT authorized with finer grained policy but authorized with `update?`
  * authorized with both finer grained policy and `update?`
  * :point_up: This also means that the current tests could be merged together

I needed to do some refactoring with the stubbing logic to make it work correctly for all these cases.