### PR TITLE
Handling relationship policy checking in replace_fields

### DIFF
--- a/lib/jsonapi/authorization/authorizing_processor.rb
+++ b/lib/jsonapi/authorization/authorizing_processor.rb
@@ -210,8 +210,16 @@ module JSONAPI
           params[:resource_id],
           context: context
         )._model
-
+        
         relationship_type = params[:relationship_type].to_sym
+        relationship_resource = @resource_klass
+          ._relationship(relationship_type)
+          .resource_klass
+          .find_by_key(
+            params[:associated_key],
+            context: context
+          )
+        related_record = related_resource._model unless related_resource.nil?
 
         authorizer.remove_to_one_relationship(source_record, relationship_type)
       end

--- a/lib/jsonapi/authorization/authorizing_processor.rb
+++ b/lib/jsonapi/authorization/authorizing_processor.rb
@@ -271,15 +271,16 @@ module JSONAPI
                 resource_class = @resource_klass.resource_for(assoc_value[:type].to_s)
                 resource_class.find_by_key(assoc_value[:id], context: context)._model
               when Array
-                resource_class = @resource_klass.resource_for(assoc_name.to_s)
+                resource_class = resource_class_for_relationship(assoc_name)
                 resource_class.find_by_keys(assoc_value, context: context).map(&:_model)
               else
                 resource_class = resource_class_for_relationship(assoc_name)
                 primary_key = resource_class._primary_key.to_sym
                 resource_class._model_class.find_by(primary_key => assoc_value)
               end
+
             {
-              relationship: @resource_klass._relationships[assoc_name],
+              relation_type: rel_type,
               relation_name: assoc_name,
               records: related_models
             }

--- a/lib/jsonapi/authorization/authorizing_processor.rb
+++ b/lib/jsonapi/authorization/authorizing_processor.rb
@@ -103,18 +103,18 @@ module JSONAPI
       end
 
       def authorize_replace_fields
+        field_data = params[:data]
         source_record = @resource_klass.find_by_key(
           params[:resource_id],
           context: context
         )._model
-
-        authorizer.replace_fields(source_record, related_models)
+        authorizer.replace_fields(source_record, related_models_with_context)
       end
 
       def authorize_create_resource
-        source_class = @resource_klass._model_class
-
-        authorizer.create_resource(source_class, related_models)
+        field_data = params[:data]
+        source_class = resource_klass._model_class
+        authorizer.create_resource(source_class, related_models_with_context)
       end
 
       def authorize_remove_resource

--- a/lib/jsonapi/authorization/authorizing_processor.rb
+++ b/lib/jsonapi/authorization/authorizing_processor.rb
@@ -216,12 +216,12 @@ module JSONAPI
           ._relationship(relationship_type)
           .resource_klass
           .find_by_key(
-            params[:associated_key],
+            params[:resource_id],
             context: context
           )
-        related_record = related_resource._model unless related_resource.nil?
+        related_record = relationship_resource._model unless relationship_resource.nil?
 
-        authorizer.remove_to_one_relationship(source_record, relationship_type)
+        authorizer.remove_to_one_relationship(source_record, related_record, relationship_type)
       end
 
       private

--- a/lib/jsonapi/authorization/authorizing_processor.rb
+++ b/lib/jsonapi/authorization/authorizing_processor.rb
@@ -275,8 +275,7 @@ module JSONAPI
                 resource_class.find_by_keys(assoc_value, context: context).map(&:_model)
               else
                 resource_class = resource_class_for_relationship(assoc_name)
-                primary_key = resource_class._primary_key.to_sym
-                resource_class._model_class.find_by(primary_key => assoc_value)
+                resource_class.find_by_key(assoc_value[:id], context: context)._model
               end
 
             {

--- a/lib/jsonapi/authorization/authorizing_processor.rb
+++ b/lib/jsonapi/authorization/authorizing_processor.rb
@@ -103,7 +103,6 @@ module JSONAPI
       end
 
       def authorize_replace_fields
-        field_data = params[:data]
         source_record = @resource_klass.find_by_key(
           params[:resource_id],
           context: context
@@ -112,7 +111,6 @@ module JSONAPI
       end
 
       def authorize_create_resource
-        field_data = params[:data]
         source_class = resource_klass._model_class
         authorizer.create_resource(source_class, related_models_with_context)
       end
@@ -283,7 +281,7 @@ module JSONAPI
             {
               relationship: @resource_klass._relationships[assoc_name],
               relation_name: assoc_name,
-              records: related_models,
+              records: related_models
             }
           end
         end

--- a/lib/jsonapi/authorization/authorizing_processor.rb
+++ b/lib/jsonapi/authorization/authorizing_processor.rb
@@ -280,17 +280,10 @@ module JSONAPI
                 primary_key = resource_class._primary_key.to_sym
                 resource_class._model_class.find_by(primary_key => assoc_value)
               end
-            old_records = if params[:resource_id]
-                            @resource_klass.find_by_key(
-                              params[:resource_id],
-                              context: context
-                            )._model.send(assoc_name)
-                          end
             {
               relationship: @resource_klass._relationships[assoc_name],
               relation_name: assoc_name,
               records: related_models,
-              old_records: old_records
             }
           end
         end

--- a/lib/jsonapi/authorization/authorizing_processor.rb
+++ b/lib/jsonapi/authorization/authorizing_processor.rb
@@ -210,18 +210,10 @@ module JSONAPI
           params[:resource_id],
           context: context
         )._model
-        
-        relationship_type = params[:relationship_type].to_sym
-        relationship_resource = @resource_klass
-          ._relationship(relationship_type)
-          .resource_klass
-          .find_by_key(
-            params[:resource_id],
-            context: context
-          )
-        related_record = relationship_resource._model unless relationship_resource.nil?
 
-        authorizer.remove_to_one_relationship(source_record, related_record, relationship_type)
+        relationship_type = params[:relationship_type].to_sym
+
+        authorizer.remove_to_one_relationship(source_record, relationship_type)
       end
 
       private

--- a/lib/jsonapi/authorization/authorizing_processor.rb
+++ b/lib/jsonapi/authorization/authorizing_processor.rb
@@ -112,7 +112,7 @@ module JSONAPI
 
       def authorize_create_resource
         source_class = resource_klass._model_class
-        authorizer.create_resource(source_class, related_models_with_context)
+        authorizer.create_resource(source_class, related_models)
       end
 
       def authorize_remove_resource

--- a/lib/jsonapi/authorization/default_pundit_authorizer.rb
+++ b/lib/jsonapi/authorization/default_pundit_authorizer.rb
@@ -271,7 +271,7 @@ module JSONAPI
 
         case relationship
         when ->(rel) { rel.polymorphic }
-          polymorphic_type = data[:records].class.name.downcase
+          polymorphic_type = data[:records].class.name.underscore
           "#{prefix}_#{relationship.class_name.downcase}_#{polymorphic_type}?"
         when JSONAPI::Relationship::ToOne
           "#{prefix}_#{assoc_name}?"

--- a/lib/jsonapi/authorization/default_pundit_authorizer.rb
+++ b/lib/jsonapi/authorization/default_pundit_authorizer.rb
@@ -98,12 +98,15 @@ module JSONAPI
       # ==== Parameters
       #
       # * +source_class+ - The class of the record to be created
-      # * +related_records_with_context+ - A hash with the relationship,
-      # relation name, and records to be associated with the new record. This
-      # will contain the records specified in the "relationships" key in the request
-      def create_resource(source_class, related_records_with_context)
+      # * +related_records+ - An array of records to be associated to the new
+      #   record. This will contain the records specified in the
+      #   "relationships" key in the request
+      def create_resource(source_class, related_records)
         ::Pundit.authorize(user, source_class, 'create?')
-        authorize_related_records(source_class, related_records_with_context)
+
+        related_records.each do |record|
+          ::Pundit.authorize(user, record, 'update?')
+        end
       end
 
       # <tt>DELETE /resources/:id</tt>

--- a/lib/jsonapi/authorization/default_pundit_authorizer.rb
+++ b/lib/jsonapi/authorization/default_pundit_authorizer.rb
@@ -292,6 +292,23 @@ module JSONAPI
           ::Pundit.authorize(user, source_record, 'update?')
         end
       end
+
+      def relationship_method(data, **options)
+        relationship = data[:relationship]
+        assoc_name   = data[:relation_name]
+        prefix       = options[:prefix]
+
+        case relationship
+        when ->(relationship) { relationship.polymorphic }
+          polymorphic_type = data[:records].class.name.downcase
+          "#{prefix}_#{relationship.class_name.downcase}_#{polymorphic_type}?"
+        when ->(relationship) { relationship.class == JSONAPI::Relationship::ToOne }
+          "#{prefix}_#{assoc_name}?"
+        else
+          prefix_preposition = prefix == 'add' ? 'to' : 'from'
+          "#{prefix}_#{prefix_preposition}_#{assoc_name}?"
+        end
+      end
     end
   end
 end

--- a/lib/jsonapi/authorization/default_pundit_authorizer.rb
+++ b/lib/jsonapi/authorization/default_pundit_authorizer.rb
@@ -238,9 +238,9 @@ module JSONAPI
       #
       # * +source_record+ - The record whose relationship is modified
       # * +relationship_type+ - The relationship type
-      def remove_to_one_relationship(source_record, related_record, relationship_type)
+      def remove_to_one_relationship(source_record, relationship_type)
         relationship_method = "remove_#{relationship_type}?"
-        authorize_relationship_operation(source_record, relationship_method, related_record)
+        authorize_relationship_operation(source_record, relationship_method)
       end
 
       # Any request including <tt>?include=other-resources</tt>

--- a/lib/jsonapi/authorization/default_pundit_authorizer.rb
+++ b/lib/jsonapi/authorization/default_pundit_authorizer.rb
@@ -110,9 +110,9 @@ module JSONAPI
               end
               unless allowed_to_remove
                 raise ::Pundit::NotAuthorizedError,
-                               query: remove_method_name,
-                               record: old_records,
-                               policy: policy
+                        query: remove_method_name,
+                        record: old_records,
+                        policy: policy
               end
           end
 
@@ -125,9 +125,9 @@ module JSONAPI
 
           unless allowed_to_add
             raise ::Pundit::NotAuthorizedError,
-                           query: add_method_name,
-                           record: new_records,
-                           policy: policy
+                    query: add_method_name,
+                    record: new_records,
+                    policy: policy
           end
         end
       end
@@ -155,9 +155,9 @@ module JSONAPI
 
           unless allowed
            raise ::Pundit::NotAuthorizedError,
-                           query: add_method_name,
-                           record: records,
-                           policy: policy
+                   query: add_method_name,
+                   record: records,
+                   policy: policy
           end
         end
       end

--- a/lib/jsonapi/authorization/default_pundit_authorizer.rb
+++ b/lib/jsonapi/authorization/default_pundit_authorizer.rb
@@ -251,10 +251,10 @@ module JSONAPI
         assoc_name   = data[:relation_name]
 
         case relationship
-        when relationship.polymorphic
+        when ->(relationship) { relationship.polymorphic }
           polymorphic_type = data[:records].class.name.downcase
           "#add_#{relationship.class_name.downcase}_#{polymorphic_type}?"
-        when relationship.class == JSONAPI::Relationship::ToOne
+        when JSONAPI::Relationship::ToOne
           "add_#{assoc_name}?"
         else
           "add_to_#{assoc_name}?"

--- a/lib/jsonapi/authorization/default_pundit_authorizer.rb
+++ b/lib/jsonapi/authorization/default_pundit_authorizer.rb
@@ -86,7 +86,7 @@ module JSONAPI
       # ==== Parameters
       #
       # * +source_record+ - The record to be modified
-      # * +related_records_with_context+ - A has with the relationship object,
+      # * +related_records_with_context+ - A hash with the association type,
       # the relationship name, an Array of new related records.
       def replace_fields(source_record, related_records_with_context)
         ::Pundit.authorize(user, source_record, 'update?')
@@ -247,7 +247,7 @@ module JSONAPI
           records = data[:records]
           case relation_type
           when :to_many
-            replace_to_many_relationship(source_class, records, relation_name)
+            replace_to_many_relationship(source_record, records, relation_name)
           when :to_one
             replace_to_one_relationship(source_record, records, relation_name)
           end

--- a/lib/jsonapi/authorization/default_pundit_authorizer.rb
+++ b/lib/jsonapi/authorization/default_pundit_authorizer.rb
@@ -191,9 +191,9 @@ module JSONAPI
       #
       # * +source_record+ - The record whose relationship is modified
       # * +relationship_type+ - The relationship type
-      def remove_to_one_relationship(source_record, relationship_type)
+      def remove_to_one_relationship(source_record, related_record, relationship_type)
         relationship_method = "remove_#{relationship_type}?"
-        authorize_relationship_operation(source_record, relationship_method)
+        authorize_relationship_operation(source_record, relationship_method, related_record)
       end
 
       # Any request including <tt>?include=other-resources</tt>

--- a/lib/jsonapi/authorization/default_pundit_authorizer.rb
+++ b/lib/jsonapi/authorization/default_pundit_authorizer.rb
@@ -95,13 +95,13 @@ module JSONAPI
           relation_name = data[:relation_name]
           records = data[:records]
 
-          # Authorize removing old records 
+          # Authorize removing old records
           case relationship
           when JSONAPI::Relationship::ToMany
             old_records = source_record.send relation_name
             authorize_relationship_operation(
-              source_record, 
-              relationship_method(data, prefix: 'remove'), 
+              source_record,
+              relationship_method(data, prefix: 'remove'),
               old_records
             )
           else
@@ -121,7 +121,7 @@ module JSONAPI
       # ==== Parameters
       #
       # * +source_class+ - The class of the record to be created
-      # * +related_records_with_context+ - A hash with the relationship, 
+      # * +related_records_with_context+ - A hash with the relationship,
       # relation name, and records to be associated with the new record. This
       # will contain the records specified in the "relationships" key in the request
       def create_resource(source_class, related_records_with_context)
@@ -270,7 +270,7 @@ module JSONAPI
         prefix       = options[:prefix] || 'add'
 
         case relationship
-        when ->(relationship) { relationship.polymorphic }
+        when ->(rel) { rel.polymorphic }
           polymorphic_type = data[:records].class.name.downcase
           "#{prefix}_#{relationship.class_name.downcase}_#{polymorphic_type}?"
         when JSONAPI::Relationship::ToOne

--- a/spec/jsonapi/authorization/default_pundit_authorizer_spec.rb
+++ b/spec/jsonapi/authorization/default_pundit_authorizer_spec.rb
@@ -162,9 +162,11 @@ RSpec.describe JSONAPI::Authorization::DefaultPunditAuthorizer do
   describe '#replace_fields' do
     let(:related_records) { Array.new(3) { Comment.new } }
     let(:related_records_with_context) do
-      Array.new(1) {
-        Hash[:relation_name, :comments, :relation_type, :to_many, :records, related_records]
-      }
+      [{
+        relation_name: :comments,
+        relation_type: :to_many,
+        records: related_records
+      }]
     end
     subject(:method_call) do
       -> { authorizer.replace_fields(source_record, related_records_with_context) }

--- a/spec/jsonapi/authorization/default_pundit_authorizer_spec.rb
+++ b/spec/jsonapi/authorization/default_pundit_authorizer_spec.rb
@@ -161,8 +161,13 @@ RSpec.describe JSONAPI::Authorization::DefaultPunditAuthorizer do
 
   describe '#replace_fields' do
     let(:related_records) { Array.new(3) { Comment.new } }
+    let(:related_records_with_context) do
+      Array.new(1) {
+        Hash[:relation_name, :comments, :relation_type, :to_many, :records, related_records]
+      }
+    end
     subject(:method_call) do
-      -> { authorizer.replace_fields(source_record, related_records) }
+      -> { authorizer.replace_fields(source_record, related_records_with_context) }
     end
 
     context 'authorized for update? on source record' do
@@ -173,18 +178,13 @@ RSpec.describe JSONAPI::Authorization::DefaultPunditAuthorizer do
         it { is_expected.not_to raise_error }
       end
 
-      context 'authorized for update? on all of the related records' do
-        before { related_records.each { |r| allow_action(r, 'update?') } }
-        it { is_expected.not_to raise_error }
+      context 'authorized for replace_comments? on source record' do
+        before { stub_policy_actions(source_record, replace_comments?: true, update?: true) }
+        it { is_expected.not_to raise_error(::Pundit::NotAuthorizedError) }
       end
 
-      context 'unauthorized for update? on any of the related records' do
-        let(:related_records) { [Comment.new(id: 1), Comment.new(id: 2)] }
-        before do
-          allow_action(related_records.first, 'update?')
-          disallow_action(related_records.last, 'update?')
-        end
-
+      context 'unauthorized for replace_comments? on source record' do
+        before { stub_policy_actions(source_record, replace_comments?: false, update?: true) }
         it { is_expected.to raise_error(::Pundit::NotAuthorizedError) }
       end
     end
@@ -197,18 +197,13 @@ RSpec.describe JSONAPI::Authorization::DefaultPunditAuthorizer do
         it { is_expected.to raise_error(::Pundit::NotAuthorizedError) }
       end
 
-      context 'authorized for update? on all of the related records' do
-        before { related_records.each { |r| allow_action(r, 'update?') } }
+      context 'authorized for replace_comments? on source record' do
+        before { stub_policy_actions(source_record, replace_comments?: true, update?: false) }
         it { is_expected.to raise_error(::Pundit::NotAuthorizedError) }
       end
 
-      context 'unauthorized for update? on any of the related records' do
-        let(:related_records) { [Comment.new(id: 1), Comment.new(id: 2)] }
-        before do
-          allow_action(related_records.first, 'update?')
-          disallow_action(related_records.last, 'update?')
-        end
-
+      context 'unauthorized for replace_comments? on source record' do
+        before { stub_policy_actions(source_record, replace_comments?: false, update?: false) }
         it { is_expected.to raise_error(::Pundit::NotAuthorizedError) }
       end
     end

--- a/spec/requests/tricky_operations_spec.rb
+++ b/spec/requests/tricky_operations_spec.rb
@@ -92,6 +92,11 @@ RSpec.describe 'Tricky operations', type: :request do
     let!(:new_comments) do
       Array.new(2) { Comment.create }
     end
+    let(:related_records_with_context) do
+      Array.new(1) {
+        Hash[:relation_name, :comments, :relation_type, :to_many, :records, new_comments]
+      }
+    end
     let(:policy_scope) { Article.where(id: article.id) }
     let(:comments_policy_scope) { Comment.all }
     before do
@@ -120,13 +125,13 @@ RSpec.describe 'Tricky operations', type: :request do
 
     context 'authorized for replace_fields on article and all new records' do
       context 'not limited by Comments policy scope' do
-        before { allow_operation('replace_fields', article, new_comments) }
+        before { allow_operation('replace_fields', article, related_records_with_context) }
         it { is_expected.to be_successful }
       end
 
       context 'limited by Comments policy scope' do
         let(:comments_policy_scope) { Comment.where("id NOT IN (?)", new_comments.map(&:id)) }
-        before { allow_operation('replace_fields', article, new_comments) }
+        before { allow_operation('replace_fields', article, related_records_with_context) }
 
         it do
           pending 'DISCUSS: Should this error out somehow?'
@@ -136,7 +141,7 @@ RSpec.describe 'Tricky operations', type: :request do
     end
 
     context 'unauthorized for replace_fields on article and all new records' do
-      before { disallow_operation('replace_fields', article, new_comments) }
+      before { disallow_operation('replace_fields', article, related_records_with_context) }
 
       it { is_expected.to be_forbidden }
     end

--- a/spec/requests/tricky_operations_spec.rb
+++ b/spec/requests/tricky_operations_spec.rb
@@ -93,9 +93,11 @@ RSpec.describe 'Tricky operations', type: :request do
       Array.new(2) { Comment.create }
     end
     let(:related_records_with_context) do
-      Array.new(1) {
-        Hash[:relation_name, :comments, :relation_type, :to_many, :records, new_comments]
-      }
+      [{
+        relation_name: :comments,
+        relation_type: :to_many,
+        records: new_comments
+      }]
     end
     let(:policy_scope) { Article.where(id: article.id) }
     let(:comments_policy_scope) { Comment.all }


### PR DESCRIPTION
FYI: This breaks tests. I haven't had time to fix them, but wanted to just put this code out to start discussion in the mean time.

This will check permissions on new records being added. It uses the same method syntax as @matthias-g's #40 recently merged PR. i.e. `add_comment`, `remove_comment`, `add_to_users`, `remove_from_users`, etc. It also creates a new method syntax for polymorphic source records. 

For example, if comments are polymorphic, in the comment policy you could check if the user has permissions to comment on an article with `add_commentable_article?(article)`. This would cover payloads like:
```
# POST api/v1/comment
data: {
  type: 'comment,
  attributes: {
    ...
  },
  relationships: {
    commentable: {
      data: { type: 'articles', id: 1 }
      }
    }
...
}
```

Also, the `remove_to_one_relationship` method was not updated to match the rest of the endpoints in @matthias-g 's branch - so it seemed to me - and I updated it here.

Again, need to update the test suite to handle this way of doing things and do more tests around polymorphic scenarios, etc. But it's something to start more conversation on perhaps.

Also this is my first non trivial code contribution to an OSS project so please let me know how I can best help out with this! This is the code I was offering to share in issue #30.