### PR TITLE
Register replace_polymorphic_to_one_relationship callback

### DIFF
--- a/lib/jsonapi/authorization/authorizing_processor.rb
+++ b/lib/jsonapi/authorization/authorizing_processor.rb
@@ -16,6 +16,11 @@ module JSONAPI
       set_callback :replace_to_many_relationship, :before, :authorize_replace_to_many_relationship
       set_callback :remove_to_many_relationship, :before, :authorize_remove_to_many_relationship
       set_callback :remove_to_one_relationship, :before, :authorize_remove_to_one_relationship
+      set_callback(
+        :replace_polymorphic_to_one_relationship,
+        :before,
+        :authorize_replace_polymorphic_to_one_relationship
+      )
 
       [
         :find,
@@ -214,6 +219,10 @@ module JSONAPI
         relationship_type = params[:relationship_type].to_sym
 
         authorizer.remove_to_one_relationship(source_record, relationship_type)
+      end
+
+      def authorize_replace_polymorphic_to_one_relationship
+        raise NotImplementedError
       end
 
       private


### PR DESCRIPTION
This pull requests registers a callback on `JSONAPI::Processor#replace_polymorphic_to_one_relationship`, which is defined as an eligible callback here: https://github.com/cerebris/jsonapi-resources/blame/master/lib/jsonapi/processor.rb#L13.

I am not sure what the expected behavior ought to be, so I have simply filled in `raise NotImplementedError` so that we can decide.

This was originally part of https://github.com/venuu/jsonapi-authorization/pull/52 (comment: https://github.com/venuu/jsonapi-authorization/pull/52#discussion_r107082505). It is not necessary for tests to pass against jsonapi-resources 0.9.