### PR TITLE
Fix error where polymorphic relation not set

### DIFF
--- a/lib/jsonapi/authorization/authorizing_processor.rb
+++ b/lib/jsonapi/authorization/authorizing_processor.rb
@@ -249,6 +249,8 @@ module JSONAPI
         [:to_one, :to_many].flat_map do |rel_type|
           data[rel_type].flat_map do |assoc_name, assoc_value|
             case assoc_value
+            when nil
+              next
             when Hash # polymorphic relationship
               resource_class = @resource_klass.resource_for(assoc_value[:type].to_s)
               resource_class.find_by_key(assoc_value[:id], context: context)._model
@@ -257,7 +259,7 @@ module JSONAPI
               primary_key = resource_class._primary_key
               resource_class._model_class.where(primary_key => assoc_value)
             end
-          end
+          end.compact
         end
       end
 


### PR DESCRIPTION
Currently if you declare a polymorphic association on a resource `AuthorizingProcessor.related_models` will error out if you try to create a record without having that relation set. The `assoc_value` will be `nil` which is not a `Hash` so the polymorphic relationship code route is not be taken. This fixes that.