### PR TITLE
Add spec for missing #replace_fields scenario

### DIFF
--- a/spec/jsonapi/authorization/default_pundit_authorizer_spec.rb
+++ b/spec/jsonapi/authorization/default_pundit_authorizer_spec.rb
@@ -187,7 +187,7 @@ RSpec.describe JSONAPI::Authorization::DefaultPunditAuthorizer do
 
     context 'authorized for replace_comments? and authorized for update? on source record' do
       before { stub_policy_actions(source_record, replace_comments?: true, update?: true) }
-      it { is_expected.not_to raise_error(::Pundit::NotAuthorizedError) }
+      it { is_expected.not_to raise_error }
     end
 
     context 'unauthorized for replace_comments? and authorized for update? on source record' do

--- a/spec/jsonapi/authorization/default_pundit_authorizer_spec.rb
+++ b/spec/jsonapi/authorization/default_pundit_authorizer_spec.rb
@@ -189,6 +189,10 @@ RSpec.describe JSONAPI::Authorization::DefaultPunditAuthorizer do
         before { stub_policy_actions(source_record, replace_comments?: false, update?: true) }
         it { is_expected.to raise_error(::Pundit::NotAuthorizedError) }
       end
+
+      context 'were replace_<type>? is undefined' do
+        it { is_expected.not_to raise_error(::Pundit::NotAuthorizedError) }
+      end
     end
 
     context 'unauthorized for update? on source record' do
@@ -206,6 +210,10 @@ RSpec.describe JSONAPI::Authorization::DefaultPunditAuthorizer do
 
       context 'unauthorized for replace_comments? on source record' do
         before { stub_policy_actions(source_record, replace_comments?: false, update?: false) }
+        it { is_expected.to raise_error(::Pundit::NotAuthorizedError) }
+      end
+
+      context 'were replace_<type>? is undefined' do
         it { is_expected.to raise_error(::Pundit::NotAuthorizedError) }
       end
     end

--- a/spec/jsonapi/authorization/default_pundit_authorizer_spec.rb
+++ b/spec/jsonapi/authorization/default_pundit_authorizer_spec.rb
@@ -208,7 +208,7 @@ RSpec.describe JSONAPI::Authorization::DefaultPunditAuthorizer do
     context 'where replace_<type>? is undefined' do
       context 'authorized for update? on source record' do
         before { stub_policy_actions(source_record, update?: true) }
-        it { is_expected.not_to raise_error(::Pundit::NotAuthorizedError) }
+        it { is_expected.not_to raise_error }
       end
 
       context 'unauthorized for update? on source record' do

--- a/spec/jsonapi/authorization/default_pundit_authorizer_spec.rb
+++ b/spec/jsonapi/authorization/default_pundit_authorizer_spec.rb
@@ -168,52 +168,51 @@ RSpec.describe JSONAPI::Authorization::DefaultPunditAuthorizer do
         records: related_records
       }]
     end
+
     subject(:method_call) do
       -> { authorizer.replace_fields(source_record, related_records_with_context) }
     end
 
-    context 'authorized for update? on source record' do
+    context 'authorized for update? on source record and related records is empty' do
       before { allow_action(source_record, 'update?') }
-
-      context 'related records is empty' do
-        let(:related_records) { [] }
-        it { is_expected.not_to raise_error }
-      end
-
-      context 'authorized for replace_comments? on source record' do
-        before { stub_policy_actions(source_record, replace_comments?: true, update?: true) }
-        it { is_expected.not_to raise_error(::Pundit::NotAuthorizedError) }
-      end
-
-      context 'unauthorized for replace_comments? on source record' do
-        before { stub_policy_actions(source_record, replace_comments?: false, update?: true) }
-        it { is_expected.to raise_error(::Pundit::NotAuthorizedError) }
-      end
-
-      context 'were replace_<type>? is undefined' do
-        it { is_expected.not_to raise_error(::Pundit::NotAuthorizedError) }
-      end
+      let(:related_records) { [] }
+      it { is_expected.not_to raise_error }
     end
 
-    context 'unauthorized for update? on source record' do
+    context 'unauthorized for update? on source record  and related records is empty' do
       before { disallow_action(source_record, 'update?') }
+      let(:related_records) { [] }
+      it { is_expected.to raise_error(::Pundit::NotAuthorizedError) }
+    end
 
-      context 'related records is empty' do
-        let(:related_records) { [] }
-        it { is_expected.to raise_error(::Pundit::NotAuthorizedError) }
+    context 'authorized for replace_comments? and authorized for update? on source record' do
+      before { stub_policy_actions(source_record, replace_comments?: true, update?: true) }
+      it { is_expected.not_to raise_error(::Pundit::NotAuthorizedError) }
+    end
+
+    context 'unauthorized for replace_comments? and authorized for update? on source record' do
+      before { stub_policy_actions(source_record, replace_comments?: false, update?: true) }
+      it { is_expected.to raise_error(::Pundit::NotAuthorizedError) }
+    end
+    
+    context 'authorized for replace_comments? and unauthorized for update? on source record' do
+      before { stub_policy_actions(source_record, replace_comments?: true, update?: false) }
+      it { is_expected.to raise_error(::Pundit::NotAuthorizedError) }
+    end
+
+    context 'unauthorized for replace_comments? and unauthorized for update? on source record' do
+      before { stub_policy_actions(source_record, replace_comments?: false, update?: false) }
+      it { is_expected.to raise_error(::Pundit::NotAuthorizedError) }
+    end
+
+    context 'where replace_<type>? is undefined' do
+      context 'authorized for update? on source record' do
+        before { stub_policy_actions(source_record, update?: true) }
+        it { is_expected.not_to raise_error(::Pundit::NotAuthorizedError) }
       end
 
-      context 'authorized for replace_comments? on source record' do
-        before { stub_policy_actions(source_record, replace_comments?: true, update?: false) }
-        it { is_expected.to raise_error(::Pundit::NotAuthorizedError) }
-      end
-
-      context 'unauthorized for replace_comments? on source record' do
-        before { stub_policy_actions(source_record, replace_comments?: false, update?: false) }
-        it { is_expected.to raise_error(::Pundit::NotAuthorizedError) }
-      end
-
-      context 'were replace_<type>? is undefined' do
+      context 'unauthorized for update? on source record' do
+        before { stub_policy_actions(source_record, update?: false) }
         it { is_expected.to raise_error(::Pundit::NotAuthorizedError) }
       end
     end

--- a/spec/jsonapi/authorization/default_pundit_authorizer_spec.rb
+++ b/spec/jsonapi/authorization/default_pundit_authorizer_spec.rb
@@ -194,7 +194,7 @@ RSpec.describe JSONAPI::Authorization::DefaultPunditAuthorizer do
       before { stub_policy_actions(source_record, replace_comments?: false, update?: true) }
       it { is_expected.to raise_error(::Pundit::NotAuthorizedError) }
     end
-    
+
     context 'authorized for replace_comments? and unauthorized for update? on source record' do
       before { stub_policy_actions(source_record, replace_comments?: true, update?: false) }
       it { is_expected.to raise_error(::Pundit::NotAuthorizedError) }


### PR DESCRIPTION
- Test scenarios where `replace_<type>?` is not defined for related records, not when user is authorized and unauthorized to `update?` source record.

As requested by @valscion at the end of issue #51's comments.