### PR TITLE
Handle has_one properly

### DIFF
--- a/lib/jsonapi/authorization/default_pundit_authorizer.rb
+++ b/lib/jsonapi/authorization/default_pundit_authorizer.rb
@@ -115,6 +115,7 @@ module JSONAPI
                     policy: policy
             end
           else
+	    records = records.is_a?(Array) ? records : [records]
             records.each do |record|
               ::Pundit.authorize(user, record, 'update?')
             end


### PR DESCRIPTION
Fix issue with has_one where iterator is applied to object causing a 500.

Spacing is goofy, I blame Atom.