### PR TITLE
Fix create_resource authorization breaking with has_one association

### DIFF
--- a/lib/jsonapi/authorization/default_pundit_authorizer.rb
+++ b/lib/jsonapi/authorization/default_pundit_authorizer.rb
@@ -115,7 +115,7 @@ module JSONAPI
                     policy: policy
             end
           else
-            records.each do |record|
+            Array(records).each do |record|
               ::Pundit.authorize(user, record, 'update?')
             end
           end

--- a/spec/dummy/app/policies/article_policy.rb
+++ b/spec/dummy/app/policies/article_policy.rb
@@ -32,6 +32,10 @@ class ArticlePolicy
     raise NotImplementedError
   end
 
+  def create_with_author?(_author)
+    raise NotImplementedError
+  end
+
   def create_with_comments?(_comments)
     raise NotImplementedError
   end

--- a/spec/jsonapi/authorization/default_pundit_authorizer_spec.rb
+++ b/spec/jsonapi/authorization/default_pundit_authorizer_spec.rb
@@ -160,127 +160,131 @@ RSpec.describe JSONAPI::Authorization::DefaultPunditAuthorizer do
   end
 
   describe '#replace_fields' do
-    let(:related_records) { Array.new(3) { Comment.new } }
-    let(:related_records_with_context) do
-      [{
-        relation_name: :comments,
-        relation_type: :to_many,
-        records: related_records
-      }]
-    end
+    describe 'with "relation_type: :to_many"' do
+      let(:related_records) { Array.new(3) { Comment.new } }
+      let(:related_records_with_context) do
+        [{
+          relation_name: :comments,
+          relation_type: :to_many,
+          records: related_records
+        }]
+      end
 
-    subject(:method_call) do
-      -> { authorizer.replace_fields(source_record, related_records_with_context) }
-    end
+      subject(:method_call) do
+        -> { authorizer.replace_fields(source_record, related_records_with_context) }
+      end
 
-    context 'authorized for update? on source record and related records is empty' do
-      before { allow_action(source_record, 'update?') }
-      let(:related_records) { [] }
-      it { is_expected.not_to raise_error }
-    end
-
-    context 'unauthorized for update? on source record  and related records is empty' do
-      before { disallow_action(source_record, 'update?') }
-      let(:related_records) { [] }
-      it { is_expected.to raise_error(::Pundit::NotAuthorizedError) }
-    end
-
-    context 'authorized for replace_comments? and authorized for update? on source record' do
-      before { stub_policy_actions(source_record, replace_comments?: true, update?: true) }
-      it { is_expected.not_to raise_error }
-    end
-
-    context 'unauthorized for replace_comments? and authorized for update? on source record' do
-      before { stub_policy_actions(source_record, replace_comments?: false, update?: true) }
-      it { is_expected.to raise_error(::Pundit::NotAuthorizedError) }
-    end
-
-    context 'authorized for replace_comments? and unauthorized for update? on source record' do
-      before { stub_policy_actions(source_record, replace_comments?: true, update?: false) }
-      it { is_expected.to raise_error(::Pundit::NotAuthorizedError) }
-    end
-
-    context 'unauthorized for replace_comments? and unauthorized for update? on source record' do
-      before { stub_policy_actions(source_record, replace_comments?: false, update?: false) }
-      it { is_expected.to raise_error(::Pundit::NotAuthorizedError) }
-    end
-
-    context 'where replace_<type>? is undefined' do
-      context 'authorized for update? on source record' do
-        before { stub_policy_actions(source_record, update?: true) }
+      context 'authorized for update? on source record and related records is empty' do
+        before { allow_action(source_record, 'update?') }
+        let(:related_records) { [] }
         it { is_expected.not_to raise_error }
       end
 
-      context 'unauthorized for update? on source record' do
-        before { stub_policy_actions(source_record, update?: false) }
+      context 'unauthorized for update? on source record  and related records is empty' do
+        before { disallow_action(source_record, 'update?') }
+        let(:related_records) { [] }
         it { is_expected.to raise_error(::Pundit::NotAuthorizedError) }
+      end
+
+      context 'authorized for replace_comments? and authorized for update? on source record' do
+        before { stub_policy_actions(source_record, replace_comments?: true, update?: true) }
+        it { is_expected.not_to raise_error }
+      end
+
+      context 'unauthorized for replace_comments? and authorized for update? on source record' do
+        before { stub_policy_actions(source_record, replace_comments?: false, update?: true) }
+        it { is_expected.to raise_error(::Pundit::NotAuthorizedError) }
+      end
+
+      context 'authorized for replace_comments? and unauthorized for update? on source record' do
+        before { stub_policy_actions(source_record, replace_comments?: true, update?: false) }
+        it { is_expected.to raise_error(::Pundit::NotAuthorizedError) }
+      end
+
+      context 'unauthorized for replace_comments? and unauthorized for update? on source record' do
+        before { stub_policy_actions(source_record, replace_comments?: false, update?: false) }
+        it { is_expected.to raise_error(::Pundit::NotAuthorizedError) }
+      end
+
+      context 'where replace_<type>? is undefined' do
+        context 'authorized for update? on source record' do
+          before { stub_policy_actions(source_record, update?: true) }
+          it { is_expected.not_to raise_error }
+        end
+
+        context 'unauthorized for update? on source record' do
+          before { stub_policy_actions(source_record, update?: false) }
+          it { is_expected.to raise_error(::Pundit::NotAuthorizedError) }
+        end
       end
     end
   end
 
   describe '#create_resource' do
-    let(:related_records) { Array.new(3) { Comment.new } }
-    let(:related_records_with_context) do
-      [{
-        relation_name: :comments,
-        relation_type: :to_many,
-        records: related_records
-      }]
-    end
-    let(:source_class) { source_record.class }
-    subject(:method_call) do
-      -> { authorizer.create_resource(source_class, related_records_with_context) }
-    end
+    describe 'with "relation_type: :to_many"' do
+      let(:related_records) { Array.new(3) { Comment.new } }
+      let(:related_records_with_context) do
+        [{
+          relation_name: :comments,
+          relation_type: :to_many,
+          records: related_records
+        }]
+      end
+      let(:source_class) { source_record.class }
+      subject(:method_call) do
+        -> { authorizer.create_resource(source_class, related_records_with_context) }
+      end
 
-    context 'authorized for create? on source class and related records is empty' do
-      before { stub_policy_actions(source_class, create?: true) }
-      let(:related_records) { [] }
-      it { is_expected.not_to raise_error }
-    end
-
-    context 'authorized for create? and authorized for create_with_<type>? on source class' do
-      before { stub_policy_actions(source_class, create_with_comments?: true, create?: true) }
-      it { is_expected.not_to raise_error }
-    end
-
-    context 'authorized for create? and unauthorized for create_with_<type>? on source class' do
-      let(:related_records) { [Comment.new(id: 1), Comment.new(id: 2)] }
-      before { stub_policy_actions(source_class, create_with_comments?: false, create?: true) }
-      it { is_expected.to raise_error(::Pundit::NotAuthorizedError) }
-    end
-
-    context 'unauthorized for create? on source class and related records is empty' do
-      let(:related_records) { [] }
-      before { stub_policy_actions(source_class, create?: false) }
-      it { is_expected.to raise_error(::Pundit::NotAuthorizedError) }
-    end
-
-    context 'unauthorized for create? and authorized for create_with_comments? on source class' do
-      before { stub_policy_actions(source_class, create_with_comments?: true, create?: false) }
-      it { is_expected.to raise_error(::Pundit::NotAuthorizedError) }
-    end
-
-    context 'unauthorized for create? and unauthorized for create_with_comments? on source class' do
-      let(:related_records) { [Comment.new(id: 1), Comment.new(id: 2)] }
-      before { stub_policy_actions(source_class, create_with_comments?: false, create?: false) }
-      it { is_expected.to raise_error(::Pundit::NotAuthorizedError) }
-    end
-
-    context 'authorized for create? where create_with_<type>? is undefined' do
-      context 'authorized for update? on related records' do
-        before do
-          stub_policy_actions(source_class, create?: true)
-          related_records.each { |r| stub_policy_actions(r, update?: true) }
-        end
+      context 'authorized for create? on source class and related records is empty' do
+        before { stub_policy_actions(source_class, create?: true) }
+        let(:related_records) { [] }
         it { is_expected.not_to raise_error }
       end
 
-      context 'unauthorized for update? on any related records' do
-        before do
-          stub_policy_actions(source_class, create?: true)
-          stub_policy_actions(related_records.first, update?: false)
-        end
+      context 'authorized for create? and authorized for create_with_<type>? on source class' do
+        before { stub_policy_actions(source_class, create_with_comments?: true, create?: true) }
+        it { is_expected.not_to raise_error }
+      end
+
+      context 'authorized for create? and unauthorized for create_with_<type>? on source class' do
+        let(:related_records) { [Comment.new(id: 1), Comment.new(id: 2)] }
+        before { stub_policy_actions(source_class, create_with_comments?: false, create?: true) }
         it { is_expected.to raise_error(::Pundit::NotAuthorizedError) }
+      end
+
+      context 'unauthorized for create? on source class and related records is empty' do
+        let(:related_records) { [] }
+        before { stub_policy_actions(source_class, create?: false) }
+        it { is_expected.to raise_error(::Pundit::NotAuthorizedError) }
+      end
+
+      context 'unauthorized for create? and authorized for create_with_comments? on source class' do
+        before { stub_policy_actions(source_class, create_with_comments?: true, create?: false) }
+        it { is_expected.to raise_error(::Pundit::NotAuthorizedError) }
+      end
+
+      context 'unauthorized for create? and unauthorized for create_with_comments? on source class' do
+        let(:related_records) { [Comment.new(id: 1), Comment.new(id: 2)] }
+        before { stub_policy_actions(source_class, create_with_comments?: false, create?: false) }
+        it { is_expected.to raise_error(::Pundit::NotAuthorizedError) }
+      end
+
+      context 'authorized for create? where create_with_<type>? is undefined' do
+        context 'authorized for update? on related records' do
+          before do
+            stub_policy_actions(source_class, create?: true)
+            related_records.each { |r| stub_policy_actions(r, update?: true) }
+          end
+          it { is_expected.not_to raise_error }
+        end
+
+        context 'unauthorized for update? on any related records' do
+          before do
+            stub_policy_actions(source_class, create?: true)
+            stub_policy_actions(related_records.first, update?: false)
+          end
+          it { is_expected.to raise_error(::Pundit::NotAuthorizedError) }
+        end
       end
     end
   end

--- a/spec/jsonapi/authorization/default_pundit_authorizer_spec.rb
+++ b/spec/jsonapi/authorization/default_pundit_authorizer_spec.rb
@@ -174,22 +174,22 @@ RSpec.describe JSONAPI::Authorization::DefaultPunditAuthorizer do
         -> { authorizer.replace_fields(source_record, related_records_with_context) }
       end
 
-      context 'authorized for replace_author? and authorized for update? on source record' do
+      context 'authorized for replace_<type>? and authorized for update? on source record' do
         before { stub_policy_actions(source_record, replace_author?: true, update?: true) }
         it { is_expected.not_to raise_error }
       end
 
-      context 'unauthorized for replace_author? and authorized for update? on source record' do
+      context 'unauthorized for replace_<type>? and authorized for update? on source record' do
         before { stub_policy_actions(source_record, replace_author?: false, update?: true) }
         it { is_expected.to raise_error(::Pundit::NotAuthorizedError) }
       end
 
-      context 'authorized for replace_author? and unauthorized for update? on source record' do
+      context 'authorized for replace_<type>? and unauthorized for update? on source record' do
         before { stub_policy_actions(source_record, replace_author?: true, update?: false) }
         it { is_expected.to raise_error(::Pundit::NotAuthorizedError) }
       end
 
-      context 'unauthorized for replace_author? and unauthorized for update? on source record' do
+      context 'unauthorized for replace_<type>? and unauthorized for update? on source record' do
         before { stub_policy_actions(source_record, replace_author?: false, update?: false) }
         it { is_expected.to raise_error(::Pundit::NotAuthorizedError) }
       end
@@ -233,22 +233,22 @@ RSpec.describe JSONAPI::Authorization::DefaultPunditAuthorizer do
         it { is_expected.to raise_error(::Pundit::NotAuthorizedError) }
       end
 
-      context 'authorized for replace_comments? and authorized for update? on source record' do
+      context 'authorized for replace_<type>? and authorized for update? on source record' do
         before { stub_policy_actions(source_record, replace_comments?: true, update?: true) }
         it { is_expected.not_to raise_error }
       end
 
-      context 'unauthorized for replace_comments? and authorized for update? on source record' do
+      context 'unauthorized for replace_<type>? and authorized for update? on source record' do
         before { stub_policy_actions(source_record, replace_comments?: false, update?: true) }
         it { is_expected.to raise_error(::Pundit::NotAuthorizedError) }
       end
 
-      context 'authorized for replace_comments? and unauthorized for update? on source record' do
+      context 'authorized for replace_<type>? and unauthorized for update? on source record' do
         before { stub_policy_actions(source_record, replace_comments?: true, update?: false) }
         it { is_expected.to raise_error(::Pundit::NotAuthorizedError) }
       end
 
-      context 'unauthorized for replace_comments? and unauthorized for update? on source record' do
+      context 'unauthorized for replace_<type>? and unauthorized for update? on source record' do
         before { stub_policy_actions(source_record, replace_comments?: false, update?: false) }
         it { is_expected.to raise_error(::Pundit::NotAuthorizedError) }
       end
@@ -292,12 +292,12 @@ RSpec.describe JSONAPI::Authorization::DefaultPunditAuthorizer do
         it { is_expected.to raise_error(::Pundit::NotAuthorizedError) }
       end
 
-      context 'unauthorized for create? and authorized for create_with_author? on source class' do
+      context 'unauthorized for create? and authorized for create_with_<type>? on source class' do
         before { stub_policy_actions(source_class, create_with_author?: true, create?: false) }
         it { is_expected.to raise_error(::Pundit::NotAuthorizedError) }
       end
 
-      context 'unauthorized for create? and unauthorized for create_with_author? on source class' do
+      context 'unauthorized for create? and unauthorized for create_with_<type>? on source class' do
         before { stub_policy_actions(source_class, create_with_author?: false, create?: false) }
         it { is_expected.to raise_error(::Pundit::NotAuthorizedError) }
       end
@@ -358,12 +358,12 @@ RSpec.describe JSONAPI::Authorization::DefaultPunditAuthorizer do
         it { is_expected.to raise_error(::Pundit::NotAuthorizedError) }
       end
 
-      context 'unauthorized for create? and authorized for create_with_comments? on source class' do
+      context 'unauthorized for create? and authorized for create_with_<type>? on source class' do
         before { stub_policy_actions(source_class, create_with_comments?: true, create?: false) }
         it { is_expected.to raise_error(::Pundit::NotAuthorizedError) }
       end
 
-      context 'unauthorized for create? and unauthorized for create_with_comments? on source class' do
+      context 'unauthorized for create? and unauthorized for create_with_<type>? on source class' do
         let(:related_records) { [Comment.new(id: 1), Comment.new(id: 2)] }
         before { stub_policy_actions(source_class, create_with_comments?: false, create?: false) }
         it { is_expected.to raise_error(::Pundit::NotAuthorizedError) }
@@ -411,22 +411,22 @@ RSpec.describe JSONAPI::Authorization::DefaultPunditAuthorizer do
       -> { authorizer.replace_to_one_relationship(source_record, related_record, :author) }
     end
 
-    context 'authorized for replace_author? and update? on record' do
+    context 'authorized for replace_<type>? and update? on record' do
       before { stub_policy_actions(source_record, replace_author?: true, update?: true) }
       it { is_expected.not_to raise_error }
     end
 
-    context 'unauthorized for replace_author? and authorized for update? on record' do
+    context 'unauthorized for replace_<type>? and authorized for update? on record' do
       before { stub_policy_actions(source_record, replace_author?: false, update?: true) }
       it { is_expected.to raise_error(::Pundit::NotAuthorizedError) }
     end
 
-    context 'authorized for replace_author? and unauthorized for update? on record' do
+    context 'authorized for replace_<type>? and unauthorized for update? on record' do
       before { stub_policy_actions(source_record, replace_author?: true, update?: false) }
       it { is_expected.not_to raise_error }
     end
 
-    context 'unauthorized for replace_author? and update? on record' do
+    context 'unauthorized for replace_<type>? and update? on record' do
       before { stub_policy_actions(source_record, replace_author?: false, update?: false) }
       it { is_expected.to raise_error(::Pundit::NotAuthorizedError) }
     end
@@ -457,22 +457,22 @@ RSpec.describe JSONAPI::Authorization::DefaultPunditAuthorizer do
       -> { authorizer.create_to_many_relationship(source_record, related_records, :comments) }
     end
 
-    context 'authorized for add_to_comments? and update? on record' do
+    context 'authorized for add_to_<type>? and update? on record' do
       before { stub_policy_actions(source_record, add_to_comments?: true, update?: true) }
       it { is_expected.not_to raise_error }
     end
 
-    context 'unauthorized for add_to_comments? and authorized for update? on record' do
+    context 'unauthorized for add_to_<type>? and authorized for update? on record' do
       before { stub_policy_actions(source_record, add_to_comments?: false, update?: true) }
       it { is_expected.to raise_error(::Pundit::NotAuthorizedError) }
     end
 
-    context 'authorized for add_to_comments? and unauthorized for update? on record' do
+    context 'authorized for add_to_<type>? and unauthorized for update? on record' do
       before { stub_policy_actions(source_record, add_to_comments?: true, update?: false) }
       it { is_expected.not_to raise_error }
     end
 
-    context 'unauthorized for add_to_comments? and update? on record' do
+    context 'unauthorized for add_to_<type>? and update? on record' do
       before { stub_policy_actions(source_record, add_to_comments?: false, update?: false) }
       it { is_expected.to raise_error(::Pundit::NotAuthorizedError) }
     end
@@ -503,22 +503,22 @@ RSpec.describe JSONAPI::Authorization::DefaultPunditAuthorizer do
       -> { authorizer.replace_to_many_relationship(article, new_comments, :comments) }
     end
 
-    context 'authorized for replace_comments? and update? on record' do
+    context 'authorized for replace_<type>? and update? on record' do
       before { stub_policy_actions(article, replace_comments?: true, update?: true) }
       it { is_expected.not_to raise_error }
     end
 
-    context 'unauthorized for replace_comments? and authorized for update? on record' do
+    context 'unauthorized for replace_<type>? and authorized for update? on record' do
       before { stub_policy_actions(article, replace_comments?: false, update?: true) }
       it { is_expected.to raise_error(::Pundit::NotAuthorizedError) }
     end
 
-    context 'authorized for replace_comments? and unauthorized for update? on record' do
+    context 'authorized for replace_<type>? and unauthorized for update? on record' do
       before { stub_policy_actions(article, replace_comments?: true, update?: false) }
       it { is_expected.not_to raise_error }
     end
 
-    context 'unauthorized for replace_comments? and update? on record' do
+    context 'unauthorized for replace_<type>? and update? on record' do
       before { stub_policy_actions(article, replace_comments?: false, update?: false) }
       it { is_expected.to raise_error(::Pundit::NotAuthorizedError) }
     end
@@ -549,22 +549,22 @@ RSpec.describe JSONAPI::Authorization::DefaultPunditAuthorizer do
       -> { authorizer.remove_to_many_relationship(article, comments_to_remove, :comments) }
     end
 
-    context 'authorized for remove_from_comments? and article? on article' do
+    context 'authorized for remove_from_<type>? and article? on article' do
       before { stub_policy_actions(article, remove_from_comments?: true, update?: true) }
       it { is_expected.not_to raise_error }
     end
 
-    context 'unauthorized for remove_from_comments? and authorized for update? on article' do
+    context 'unauthorized for remove_from_<type>? and authorized for update? on article' do
       before { stub_policy_actions(article, remove_from_comments?: false, update?: true) }
       it { is_expected.to raise_error(::Pundit::NotAuthorizedError) }
     end
 
-    context 'authorized for remove_from_comments? and unauthorized for update? on article' do
+    context 'authorized for remove_from_<type>? and unauthorized for update? on article' do
       before { stub_policy_actions(article, remove_from_comments?: true, update?: false) }
       it { is_expected.not_to raise_error }
     end
 
-    context 'unauthorized for remove_from_comments? and update? on article' do
+    context 'unauthorized for remove_from_<type>? and update? on article' do
       before { stub_policy_actions(article, remove_from_comments?: false, update?: false) }
       it { is_expected.to raise_error(::Pundit::NotAuthorizedError) }
     end
@@ -593,22 +593,22 @@ RSpec.describe JSONAPI::Authorization::DefaultPunditAuthorizer do
       -> { authorizer.remove_to_one_relationship(source_record, :author) }
     end
 
-    context 'authorized for remove_author? and article? on record' do
+    context 'authorized for remove_<type>? and article? on record' do
       before { stub_policy_actions(source_record, remove_author?: true, update?: true) }
       it { is_expected.not_to raise_error }
     end
 
-    context 'unauthorized for remove_author? and authorized for update? on record' do
+    context 'unauthorized for remove_<type>? and authorized for update? on record' do
       before { stub_policy_actions(source_record, remove_author?: false, update?: true) }
       it { is_expected.to raise_error(::Pundit::NotAuthorizedError) }
     end
 
-    context 'authorized for remove_author? and unauthorized for update? on record' do
+    context 'authorized for remove_<type>? and unauthorized for update? on record' do
       before { stub_policy_actions(source_record, remove_author?: true, update?: false) }
       it { is_expected.not_to raise_error }
     end
 
-    context 'unauthorized for remove_author? and update? on record' do
+    context 'unauthorized for remove_<type>? and update? on record' do
       before { stub_policy_actions(source_record, remove_author?: false, update?: false) }
       it { is_expected.to raise_error(::Pundit::NotAuthorizedError) }
     end


### PR DESCRIPTION
We seem to have missed a test case for the `related_records_with_context` cases and so have got this bug. Credits to @nbarthel for discovering this case in #65, thanks!

Closes #65