### PR TITLE
Authorize replacing of a polymorphic has-one relationship

### DIFF
--- a/lib/jsonapi/authorization/authorizing_processor.rb
+++ b/lib/jsonapi/authorization/authorizing_processor.rb
@@ -222,7 +222,34 @@ module JSONAPI
       end
 
       def authorize_replace_polymorphic_to_one_relationship
-        raise NotImplementedError
+        return authorize_remove_to_one_relationship if params[:key_value].nil?
+
+        source_resource = @resource_klass.find_by_key(
+          params[:resource_id],
+          context: context
+        )
+        source_record = source_resource._model
+
+        relationship_type = params[:relationship_type].to_sym
+        relationship = @resource_klass._relationship(relationship_type)
+        relation_name = relationship.relation_name(context: context)
+        related_resource_klass = @resource_klass
+          .resource_for(
+            source_record.association(relation_name).klass.to_s
+          )
+
+        new_related_resource = related_resource_klass
+          .find_by_key(
+            params[:key_value],
+            context: context
+          )
+        new_related_record = new_related_resource._model unless new_related_resource.nil?
+
+        authorizer.replace_to_one_relationship(
+          source_record,
+          new_related_record,
+          relationship_type
+        )
       end
 
       private

--- a/lib/jsonapi/authorization/authorizing_processor.rb
+++ b/lib/jsonapi/authorization/authorizing_processor.rb
@@ -16,6 +16,11 @@ module JSONAPI
       set_callback :create_to_many_relationships, :before, :authorize_create_to_many_relationships
       set_callback :replace_to_many_relationships, :before, :authorize_replace_to_many_relationships
       set_callback :remove_to_many_relationships, :before, :authorize_remove_to_many_relationships
+      set_callback(
+        :replace_polymorphic_to_one_relationship,
+        :before,
+        :authorize_replace_polymorphic_to_one_relationship
+      )
 
       [
         :find,
@@ -214,6 +219,10 @@ module JSONAPI
         relationship_type = params[:relationship_type].to_sym
 
         authorizer.remove_to_one_relationship(source_record, relationship_type)
+      end
+
+      def authorize_replace_polymorphic_to_one_relationship
+        raise NotImplementedError
       end
 
       private

--- a/spec/requests/relationship_operations_spec.rb
+++ b/spec/requests/relationship_operations_spec.rb
@@ -263,13 +263,15 @@ RSpec.describe 'Relationship operations', type: :request do
   describe 'PATCH /tags/:id/relationships/taggable' do
     subject(:last_response) { patch("/tags/#{tag.id}/relationships/taggable", json) }
 
-    let!(:old_taggable) { Article.create(external_id: 'old-article-id') }
+    let!(:old_taggable) { Comment.create }
     let!(:tag) { Tag.create(taggable: old_taggable) }
     let(:policy_scope) { Article.all }
+    let(:comment_policy_scope) { Article.all }
     let(:tag_policy_scope) { Tag.all }
 
     before do
       allow_any_instance_of(TagPolicy::Scope).to receive(:resolve).and_return(tag_policy_scope)
+      allow_any_instance_of(CommentPolicy::Scope).to receive(:resolve).and_return(comment_policy_scope)
     end
 
     describe 'when replacing with a new taggable' do

--- a/spec/requests/relationship_operations_spec.rb
+++ b/spec/requests/relationship_operations_spec.rb
@@ -259,6 +259,84 @@ RSpec.describe 'Relationship operations', type: :request do
     end
   end
 
+  # Polymorphic has-one relationship replacing
+  describe 'PATCH /tags/:id/relationships/taggable' do
+    subject(:last_response) { patch("/tags/#{tag.id}/relationships/taggable", json) }
+
+    let!(:old_taggable) { Article.create(external_id: 'old-article-id') }
+    let!(:tag) { Tag.create(taggable: old_taggable) }
+    let(:policy_scope) { Article.all }
+    let(:tag_policy_scope) { Tag.all }
+
+    before do
+      allow_any_instance_of(TagPolicy::Scope).to receive(:resolve).and_return(tag_policy_scope)
+    end
+
+    describe 'when replacing with a new taggable' do
+      let!(:new_taggable) { Article.create(external_id: 'new-article-id') }
+      let(:json) do
+        <<-EOS.strip_heredoc
+        {
+          "data": {
+            "type": "articles",
+            "id": "#{new_taggable.external_id}"
+          }
+        }
+        EOS
+      end
+
+      context 'unauthorized for replace_to_one_relationship' do
+        before { disallow_operation('replace_to_one_relationship', tag, new_taggable, :taggable) }
+        it { is_expected.to be_forbidden }
+      end
+
+      context 'authorized for replace_to_one_relationship' do
+        before { allow_operation('replace_to_one_relationship', tag, new_taggable, :taggable) }
+        it { is_expected.to be_successful }
+
+        context 'limited by policy scope on taggable', skip: 'DISCUSS' do
+          let(:policy_scope) { Article.where.not(id: tag.taggable.id) }
+          it { is_expected.to be_not_found }
+        end
+
+        # If this happens in real life, it's mostly a bug. We want to document the
+        # behaviour in that case anyway, as it might be surprising.
+        context 'limited by policy scope on tag' do
+          let(:tag_policy_scope) { Tag.where.not(id: tag.id) }
+          it { is_expected.to be_not_found }
+        end
+      end
+    end
+
+    # https://github.com/cerebris/jsonapi-resources/issues/1081
+    describe 'when nullifying the taggable', skip: 'Broken upstream' do
+      let(:new_taggable) { nil }
+      let(:json) { '{ "data": null }' }
+
+      context 'unauthorized for remove_to_one_relationship' do
+        before { disallow_operation('remove_to_one_relationship', tag, :taggable) }
+        it { is_expected.to be_forbidden }
+      end
+
+      context 'authorized for remove_to_one_relationship' do
+        before { allow_operation('remove_to_one_relationship', tag, :taggable) }
+        it { is_expected.to be_successful }
+
+        context 'limited by policy scope on taggable', skip: 'DISCUSS' do
+          let(:policy_scope) { Article.where.not(id: tag.taggable.id) }
+          it { is_expected.to be_not_found }
+        end
+
+        # If this happens in real life, it's mostly a bug. We want to document the
+        # behaviour in that case anyway, as it might be surprising.
+        context 'limited by policy scope on tag' do
+          let(:tag_policy_scope) { Tag.where.not(id: tag.id) }
+          it { is_expected.to be_not_found }
+        end
+      end
+    end
+  end
+
   describe 'DELETE /articles/:id/relationships/comments' do
     let(:article) { articles(:article_with_comments) }
     let(:comments_to_remove) { article.comments.limit(2) }


### PR DESCRIPTION
This PR picks off from #53 and adds authorization for the replacing of a polymorphic has-one relationship.

Seems like `jsonapi-resources` is broken and won't allow clearing of a polymorhpic has-one relationship by sending

`PATCH /tags/1/relationships/taggable`

```
{ "data": null }
```

The issue upstream is here: https://github.com/cerebris/jsonapi-resources/issues/1081

I skipped the tests for the relationship nullification for now.