### PR TITLE
Fix relation_name lambda being broken

### DIFF
--- a/lib/jsonapi/authorization/authorizing_processor.rb
+++ b/lib/jsonapi/authorization/authorizing_processor.rb
@@ -347,7 +347,7 @@ module JSONAPI
             next_resource_klass = relationship.resource_klass
             Array.wrap(
               source_record.public_send(
-                relationship.relation_name(context)
+                relationship.relation_name(context: context)
               )
             ).each do |next_source_record|
               deep.each do |next_include_item|
@@ -364,7 +364,7 @@ module JSONAPI
           case relationship
           when JSONAPI::Relationship::ToOne
             related_record = source_record.public_send(
-              relationship.relation_name(context)
+              relationship.relation_name(context: context)
             )
             return if related_record.nil?
             authorizer.include_has_one_resource(source_record, related_record)

--- a/lib/jsonapi/authorization/pundit_scoped_resource.rb
+++ b/lib/jsonapi/authorization/pundit_scoped_resource.rb
@@ -31,7 +31,7 @@ module JSONAPI
 
       def fetch_relationship(association_name)
         relationships = self.class._relationships.select do |_k, v|
-          v.relation_name(context) == association_name
+          v.relation_name(context: context) == association_name
         end
         if relationships.empty?
           nil

--- a/lib/jsonapi/authorization/pundit_scoped_resource.rb
+++ b/lib/jsonapi/authorization/pundit_scoped_resource.rb
@@ -31,7 +31,7 @@ module JSONAPI
 
       def fetch_relationship(association_name)
         relationships = self.class._relationships.select do |_k, v|
-          v.relation_name({}) == association_name
+          v.relation_name(context) == association_name
         end
         if relationships.empty?
           nil


### PR DESCRIPTION
This fixes #80

It seems to be that JR always passes a hash to the `relation_name` accessors, with the `context` under key `:context`

https://github.com/cerebris/jsonapi-resources/blob/v0.9.0/lib/jsonapi/resource.rb#L250

Let's just use that everywhere in `jsonapi-authorization`, too.

It's a bit odd that JR passes way more information down the same `relation_name` when in the scope of processor, but that doesn't seem to be important to us. Documentation only refers to fetching the `context` from the options, and AFAICT, doesn't tell about what else is in the options hash:

http://jsonapi-resources.com/v0.9/guide/resources.html#Options

```rb
class BookResource < JSONAPI::Resource
  # Only book_admins may see unapproved comments for a book. Using
  # a lambda to select the correct relation on the model
  has_many :book_comments, relation_name: -> (options = {}) {
    context = options[:context]
    current_user = context ? context[:current_user] : nil
    unless current_user && current_user.book_admin
      :approved_book_comments
    else
      :book_comments
    end
  }
  ...
end
```