### PR TITLE
Fix a bug for checking JSONAPI::Relationship::ToOne authorization

### DIFF
--- a/lib/jsonapi/authorization/authorizing_processor.rb
+++ b/lib/jsonapi/authorization/authorizing_processor.rb
@@ -66,21 +66,20 @@ module JSONAPI
           params[:parent_key],
           context: context
         )
+        parent_record = parent_resource._model
 
         relationship = @resource_klass._relationship(params[:relationship_type].to_sym)
 
-        related_resource =
+        related_record =
           case relationship
           when JSONAPI::Relationship::ToOne
-            parent_resource.public_send(params[:relationship_type].to_sym)
+            parent_record.public_send(params[:relationship_type].to_sym)
           when JSONAPI::Relationship::ToMany
             # Do nothing — already covered by policy scopes
           else
             raise "Unexpected relationship type: #{relationship.inspect}"
           end
 
-        parent_record = parent_resource._model
-        related_record = related_resource._model unless related_resource.nil?
         authorizer.show_relationship(parent_record, related_record)
       end
 
@@ -91,10 +90,8 @@ module JSONAPI
 
         source_resource = source_klass.find_by_key(source_id, context: context)
 
-        related_resource = source_resource.public_send(relationship_type)
-
         source_record = source_resource._model
-        related_record = related_resource._model unless related_resource.nil?
+        related_record = source_record.public_send(relationship_type)
         authorizer.show_related_resource(source_record, related_record)
       end
 


### PR DESCRIPTION
I had an error when I wanted to fetch a relationship and managed to fix it like this.
I'm not sure if that is the most correct way to do it but it worked for me.
Thanks for your efforts!