### PR TITLE
Default pundit authorizer keyword args

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,5 @@
 AllCops:
+  TargetRubyVersion: 2.1
   Exclude:
     - 'bin/*'
     - 'spec/dummy/db/schema.rb'

--- a/lib/jsonapi/authorization/authorizing_processor.rb
+++ b/lib/jsonapi/authorization/authorizing_processor.rb
@@ -271,7 +271,7 @@ module JSONAPI
       private
 
       def authorizer
-        @authorizer ||= ::JSONAPI::Authorization.configuration.authorizer.new(context)
+        @authorizer ||= ::JSONAPI::Authorization.configuration.authorizer.new(context: context)
       end
 
       # TODO: Communicate with upstream to fix this nasty hack

--- a/lib/jsonapi/authorization/authorizing_processor.rb
+++ b/lib/jsonapi/authorization/authorizing_processor.rb
@@ -58,7 +58,7 @@ module JSONAPI
           context: context
         )._model
 
-        authorizer.show(record)
+        authorizer.show(source_record: record)
       end
 
       def authorize_show_relationship

--- a/lib/jsonapi/authorization/authorizing_processor.rb
+++ b/lib/jsonapi/authorization/authorizing_processor.rb
@@ -114,12 +114,18 @@ module JSONAPI
           params[:resource_id],
           context: context
         )._model
-        authorizer.replace_fields(source_record, related_models_with_context)
+        authorizer.replace_fields(
+          source_record: source_record,
+          related_records_with_context: related_models_with_context
+        )
       end
 
       def authorize_create_resource
         source_class = resource_klass._model_class
-        authorizer.create_resource(source_class, related_models_with_context)
+        authorizer.create_resource(
+          source_class: source_class,
+          related_records_with_context: related_models_with_context
+        )
       end
 
       def authorize_remove_resource
@@ -166,7 +172,11 @@ module JSONAPI
         relationship_type = params[:relationship_type].to_sym
         related_models = model_class_for_relationship(relationship_type).find(params[:data])
 
-        authorizer.create_to_many_relationship(source_record, related_models, relationship_type)
+        authorizer.create_to_many_relationship(
+          source_record: source_record,
+          new_related_records: related_models,
+          relationship_type: relationship_type
+        )
       end
 
       def authorize_replace_to_many_relationships
@@ -180,9 +190,9 @@ module JSONAPI
         new_related_records = model_class_for_relationship(relationship_type).find(params[:data])
 
         authorizer.replace_to_many_relationship(
-          source_record,
-          new_related_records,
-          relationship_type
+          source_record: source_record,
+          new_related_records: new_related_records,
+          relationship_type: relationship_type
         )
       end
 
@@ -206,9 +216,9 @@ module JSONAPI
         related_records = related_resources.map(&:_model)
 
         authorizer.remove_to_many_relationship(
-          source_record,
-          related_records,
-          relationship_type
+          source_record: source_record,
+          related_records: related_records,
+          relationship_type: relationship_type
         )
       end
 
@@ -220,7 +230,9 @@ module JSONAPI
 
         relationship_type = params[:relationship_type].to_sym
 
-        authorizer.remove_to_one_relationship(source_record, relationship_type)
+        authorizer.remove_to_one_relationship(
+          source_record: source_record, relationship_type: relationship_type
+        )
       end
 
       def authorize_replace_polymorphic_to_one_relationship
@@ -369,11 +381,13 @@ module JSONAPI
               relationship.relation_name(context: context)
             )
             return if related_record.nil?
-            authorizer.include_has_one_resource(source_record, related_record)
+            authorizer.include_has_one_resource(
+              source_record: source_record, related_record: related_record
+            )
           when JSONAPI::Relationship::ToMany
             authorizer.include_has_many_resource(
-              source_record,
-              relationship.resource_klass._model_class
+              source_record: source_record,
+              record_class: relationship.resource_klass._model_class
             )
           else
             raise "Unexpected relationship type: #{relationship.inspect}"

--- a/lib/jsonapi/authorization/authorizing_processor.rb
+++ b/lib/jsonapi/authorization/authorizing_processor.rb
@@ -81,7 +81,7 @@ module JSONAPI
 
         parent_record = parent_resource._model
         related_record = related_resource._model unless related_resource.nil?
-        authorizer.show_relationship(parent_record, related_record)
+        authorizer.show_relationship(source_record: parent_record, related_record: related_record)
       end
 
       def authorize_show_related_resource
@@ -149,9 +149,9 @@ module JSONAPI
         new_related_record = new_related_resource._model unless new_related_resource.nil?
 
         authorizer.replace_to_one_relationship(
-          source_record,
-          new_related_record,
-          relationship_type
+          source_record: source_record,
+          new_related_record: new_related_record,
+          relationship_type: relationship_type
         )
       end
 
@@ -248,9 +248,9 @@ module JSONAPI
 
         relationship_type = params[:relationship_type].to_sym
         authorizer.replace_to_one_relationship(
-          source_record,
-          new_related_record,
-          relationship_type
+          source_record: source_record,
+          new_related_record: new_related_record,
+          relationship_type: relationship_type
         )
       end
 

--- a/lib/jsonapi/authorization/authorizing_processor.rb
+++ b/lib/jsonapi/authorization/authorizing_processor.rb
@@ -49,7 +49,7 @@ module JSONAPI
       end
 
       def authorize_find
-        authorizer.find(@resource_klass._model_class)
+        authorizer.find(source_class: @resource_klass._model_class)
       end
 
       def authorize_show

--- a/lib/jsonapi/authorization/authorizing_processor.rb
+++ b/lib/jsonapi/authorization/authorizing_processor.rb
@@ -106,7 +106,7 @@ module JSONAPI
           context: context
         )._model
 
-        authorizer.show_related_resources(source_record)
+        authorizer.show_related_resources(source_record: source_record)
       end
 
       def authorize_replace_fields

--- a/lib/jsonapi/authorization/authorizing_processor.rb
+++ b/lib/jsonapi/authorization/authorizing_processor.rb
@@ -128,7 +128,7 @@ module JSONAPI
           context: context
         )._model
 
-        authorizer.remove_resource(record)
+        authorizer.remove_resource(source_record: record)
       end
 
       def authorize_replace_to_one_relationship

--- a/lib/jsonapi/authorization/authorizing_processor.rb
+++ b/lib/jsonapi/authorization/authorizing_processor.rb
@@ -95,7 +95,9 @@ module JSONAPI
 
         source_record = source_resource._model
         related_record = related_resource._model unless related_resource.nil?
-        authorizer.show_related_resource(source_record, related_record)
+        authorizer.show_related_resource(
+          source_record: source_record, related_record: related_record
+        )
       end
 
       def authorize_show_related_resources

--- a/lib/jsonapi/authorization/default_pundit_authorizer.rb
+++ b/lib/jsonapi/authorization/default_pundit_authorizer.rb
@@ -65,7 +65,7 @@ module JSONAPI
       # * +source_record+ - The record whose relationship is queried
       # * +related_record+ - The associated record to show or +nil+ if the
       #   associated record was not found
-      def show_related_resource(source_record, related_record)
+      def show_related_resource(source_record:, related_record:)
         ::Pundit.authorize(user, source_record, 'show?')
         ::Pundit.authorize(user, related_record, 'show?') unless related_record.nil?
       end

--- a/lib/jsonapi/authorization/default_pundit_authorizer.rb
+++ b/lib/jsonapi/authorization/default_pundit_authorizer.rb
@@ -36,7 +36,7 @@ module JSONAPI
       # ==== Parameters
       #
       # * +source_record+ - The record to show
-      def show(source_record)
+      def show(source_record:)
         ::Pundit.authorize(user, source_record, 'show?')
       end
 

--- a/lib/jsonapi/authorization/default_pundit_authorizer.rb
+++ b/lib/jsonapi/authorization/default_pundit_authorizer.rb
@@ -51,7 +51,7 @@ module JSONAPI
       # * +related_record+ - The associated +has_one+ record to show or +nil+
       #   if the associated record was not found. For a +has_many+ association,
       #   this will always be +nil+
-      def show_relationship(source_record, related_record)
+      def show_relationship(source_record:, related_record:)
         ::Pundit.authorize(user, source_record, 'show?')
         ::Pundit.authorize(user, related_record, 'show?') unless related_record.nil?
       end
@@ -140,7 +140,7 @@ module JSONAPI
       # * +source_record+ - The record whose relationship is modified
       # * +new_related_record+ - The new record replacing the old record
       # * +relationship_type+ - The relationship type
-      def replace_to_one_relationship(source_record, new_related_record, relationship_type)
+      def replace_to_one_relationship(source_record:, new_related_record:, relationship_type:)
         relationship_method = "replace_#{relationship_type}?"
         authorize_relationship_operation(source_record, relationship_method, new_related_record)
       end
@@ -273,7 +273,11 @@ module JSONAPI
             if records.nil?
               remove_to_one_relationship(source_record, relation_name)
             else
-              replace_to_one_relationship(source_record, records, relation_name)
+              replace_to_one_relationship(
+                source_record: source_record,
+                new_related_record: records,
+                relationship_type: relation_name
+              )
             end
           end
         end

--- a/lib/jsonapi/authorization/default_pundit_authorizer.rb
+++ b/lib/jsonapi/authorization/default_pundit_authorizer.rb
@@ -18,7 +18,7 @@ module JSONAPI
       # ==== Parameters
       #
       # * +context+ - The context passed down from the controller layer
-      def initialize(context)
+      def initialize(context:)
         @user = JSONAPI::Authorization.configuration.user_context(context)
       end
 

--- a/lib/jsonapi/authorization/default_pundit_authorizer.rb
+++ b/lib/jsonapi/authorization/default_pundit_authorizer.rb
@@ -77,7 +77,7 @@ module JSONAPI
       # ==== Parameters
       #
       # * +source_record+ - The record whose relationship is queried
-      def show_related_resources(source_record)
+      def show_related_resources(source_record:)
         ::Pundit.authorize(user, source_record, 'show?')
       end
 

--- a/lib/jsonapi/authorization/default_pundit_authorizer.rb
+++ b/lib/jsonapi/authorization/default_pundit_authorizer.rb
@@ -127,7 +127,7 @@ module JSONAPI
       # ==== Parameters
       #
       # * +source_record+ - The record to be removed
-      def remove_resource(source_record)
+      def remove_resource(source_record:)
         ::Pundit.authorize(user, source_record, 'destroy?')
       end
 

--- a/lib/jsonapi/authorization/default_pundit_authorizer.rb
+++ b/lib/jsonapi/authorization/default_pundit_authorizer.rb
@@ -27,7 +27,7 @@ module JSONAPI
       # ==== Parameters
       #
       # * +source_class+ - The source class (e.g. +Article+ for +ArticleResource+)
-      def find(source_class)
+      def find(source_class:)
         ::Pundit.authorize(user, source_class, 'index?')
       end
 

--- a/lib/jsonapi/authorization/default_pundit_authorizer.rb
+++ b/lib/jsonapi/authorization/default_pundit_authorizer.rb
@@ -88,9 +88,12 @@ module JSONAPI
       # * +source_record+ - The record to be modified
       # * +related_records_with_context+ - A hash with the association type,
       # the relationship name, an Array of new related records.
-      def replace_fields(source_record, related_records_with_context)
+      def replace_fields(source_record:, related_records_with_context:)
         ::Pundit.authorize(user, source_record, 'update?')
-        authorize_related_records(source_record, related_records_with_context)
+        authorize_related_records(
+          source_record: source_record,
+          related_records_with_context: related_records_with_context
+        )
       end
 
       # <tt>POST /resources</tt>
@@ -100,7 +103,7 @@ module JSONAPI
       # * +source_class+ - The class of the record to be created
       # * +related_records_with_context+ - A has with the association type,
       # the relationship name, and an Array of new related records.
-      def create_resource(source_class, related_records_with_context)
+      def create_resource(source_class:, related_records_with_context:)
         ::Pundit.authorize(user, source_class, 'create?')
         related_records_with_context.each do |data|
           relation_name = data[:relation_name]
@@ -142,7 +145,11 @@ module JSONAPI
       # * +relationship_type+ - The relationship type
       def replace_to_one_relationship(source_record:, new_related_record:, relationship_type:)
         relationship_method = "replace_#{relationship_type}?"
-        authorize_relationship_operation(source_record, relationship_method, new_related_record)
+        authorize_relationship_operation(
+          source_record: source_record,
+          relationship_method: relationship_method,
+          related_record_or_records: new_related_record
+        )
       end
 
       # <tt>POST /resources/:id/relationships/other-resources</tt>
@@ -154,9 +161,13 @@ module JSONAPI
       # * +source_record+ - The record whose relationship is modified
       # * +new_related_records+ - The new records to be added to the association
       # * +relationship_type+ - The relationship type
-      def create_to_many_relationship(source_record, new_related_records, relationship_type)
+      def create_to_many_relationship(source_record:, new_related_records:, relationship_type:)
         relationship_method = "add_to_#{relationship_type}?"
-        authorize_relationship_operation(source_record, relationship_method, new_related_records)
+        authorize_relationship_operation(
+          source_record: source_record,
+          relationship_method: relationship_method,
+          related_record_or_records: new_related_records
+        )
       end
 
       # <tt>PATCH /resources/:id/relationships/other-resources</tt>
@@ -169,9 +180,13 @@ module JSONAPI
       # * +new_related_records+ - The new records replacing the entire +has_many+
       #   association
       # * +relationship_type+ - The relationship type
-      def replace_to_many_relationship(source_record, new_related_records, relationship_type)
+      def replace_to_many_relationship(source_record:, new_related_records:, relationship_type:)
         relationship_method = "replace_#{relationship_type}?"
-        authorize_relationship_operation(source_record, relationship_method, new_related_records)
+        authorize_relationship_operation(
+          source_record: source_record,
+          relationship_method: relationship_method,
+          related_record_or_records: new_related_records
+        )
       end
 
       # <tt>DELETE /resources/:id/relationships/other-resources</tt>
@@ -183,9 +198,13 @@ module JSONAPI
       # * +source_record+ - The record whose relationship is modified
       # * +related_records+ - The records which will be disassociated from +source_record+
       # * +relationship_type+ - The relationship type
-      def remove_to_many_relationship(source_record, related_records, relationship_type)
+      def remove_to_many_relationship(source_record:, related_records:, relationship_type:)
         relationship_method = "remove_from_#{relationship_type}?"
-        authorize_relationship_operation(source_record, relationship_method, related_records)
+        authorize_relationship_operation(
+          source_record: source_record,
+          relationship_method: relationship_method,
+          related_record_or_records: related_records
+        )
       end
 
       # <tt>DELETE /resources/:id/relationships/another-resource</tt>
@@ -196,9 +215,12 @@ module JSONAPI
       #
       # * +source_record+ - The record whose relationship is modified
       # * +relationship_type+ - The relationship type
-      def remove_to_one_relationship(source_record, relationship_type)
+      def remove_to_one_relationship(source_record:, relationship_type:)
         relationship_method = "remove_#{relationship_type}?"
-        authorize_relationship_operation(source_record, relationship_method)
+        authorize_relationship_operation(
+          source_record: source_record,
+          relationship_method: relationship_method
+        )
       end
 
       # Any request including <tt>?include=other-resources</tt>
@@ -216,9 +238,11 @@ module JSONAPI
       #                     article.comments check
       # * +record_class+ - The underlying record class for the relationships
       #                    resource.
-      def include_has_many_resource(_source_record, record_class)
+      # rubocop:disable Lint/UnusedMethodArgument
+      def include_has_many_resource(source_record:, record_class:)
         ::Pundit.authorize(user, record_class, 'index?')
       end
+      # rubocop:enable Lint/UnusedMethodArgument
 
       # Any request including <tt>?include=another-resource</tt>
       #
@@ -231,16 +255,18 @@ module JSONAPI
       # * +source_record+ — The source relationship record, e.g. an Article in
       #                     article.author check
       # * +related_record+ - The associated record to return
-      def include_has_one_resource(_source_record, related_record)
+      # rubocop:disable Lint/UnusedMethodArgument
+      def include_has_one_resource(source_record:, related_record:)
         ::Pundit.authorize(user, related_record, 'show?')
       end
+      # rubocop:enable Lint/UnusedMethodArgument
 
       private
 
       def authorize_relationship_operation(
-        source_record,
-        relationship_method,
-        related_record_or_records = nil
+        source_record:,
+        relationship_method:,
+        related_record_or_records: nil
       )
         policy = ::Pundit.policy(user, source_record)
         if policy.respond_to?(relationship_method)
@@ -261,17 +287,24 @@ module JSONAPI
         end
       end
 
-      def authorize_related_records(source_record, related_records_with_context)
+      def authorize_related_records(source_record:, related_records_with_context:)
         related_records_with_context.each do |data|
           relation_type = data[:relation_type]
           relation_name = data[:relation_name]
           records = data[:records]
           case relation_type
           when :to_many
-            replace_to_many_relationship(source_record, records, relation_name)
+            replace_to_many_relationship(
+              source_record: source_record,
+              new_related_records: records,
+              relationship_type: relation_name
+            )
           when :to_one
             if records.nil?
-              remove_to_one_relationship(source_record, relation_name)
+              remove_to_one_relationship(
+                source_record: source_record,
+                relationship_type: relation_name
+              )
             else
               replace_to_one_relationship(
                 source_record: source_record,

--- a/spec/jsonapi/authorization/default_pundit_authorizer_spec.rb
+++ b/spec/jsonapi/authorization/default_pundit_authorizer_spec.rb
@@ -186,7 +186,7 @@ RSpec.describe JSONAPI::Authorization::DefaultPunditAuthorizer do
 
   describe '#show_related_resources' do
     subject(:method_call) do
-      -> { authorizer.show_related_resources(source_record) }
+      -> { authorizer.show_related_resources(source_record: source_record) }
     end
 
     context 'authorized for show? on record' do

--- a/spec/jsonapi/authorization/default_pundit_authorizer_spec.rb
+++ b/spec/jsonapi/authorization/default_pundit_authorizer_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe JSONAPI::Authorization::DefaultPunditAuthorizer do
 
   describe '#show' do
     subject(:method_call) do
-      -> { authorizer.show(source_record) }
+      -> { authorizer.show(source_record: source_record) }
     end
 
     context 'authorized for show? on record' do

--- a/spec/jsonapi/authorization/default_pundit_authorizer_spec.rb
+++ b/spec/jsonapi/authorization/default_pundit_authorizer_spec.rb
@@ -73,7 +73,11 @@ RSpec.describe JSONAPI::Authorization::DefaultPunditAuthorizer do
 
   describe '#show_relationship' do
     subject(:method_call) do
-      -> { authorizer.show_relationship(source_record: source_record, related_record: related_record) }
+      lambda do
+        authorizer.show_relationship(
+          source_record: source_record, related_record: related_record
+        )
+      end
     end
 
     context 'authorized for show? on source record' do
@@ -474,13 +478,13 @@ RSpec.describe JSONAPI::Authorization::DefaultPunditAuthorizer do
   describe '#replace_to_one_relationship' do
     let(:related_record) { User.new }
     subject(:method_call) do
-      -> {
+      lambda do
         authorizer.replace_to_one_relationship(
           source_record: source_record,
           new_related_record: related_record,
           relationship_type: :author
         )
-      }
+      end
     end
 
     context 'authorized for replace_<type>? and update? on record' do

--- a/spec/jsonapi/authorization/default_pundit_authorizer_spec.rb
+++ b/spec/jsonapi/authorization/default_pundit_authorizer_spec.rb
@@ -466,7 +466,7 @@ RSpec.describe JSONAPI::Authorization::DefaultPunditAuthorizer do
 
   describe '#remove_resource' do
     subject(:method_call) do
-      -> { authorizer.remove_resource(source_record) }
+      -> { authorizer.remove_resource(source_record: source_record) }
     end
 
     context 'authorized for destroy? on record' do

--- a/spec/jsonapi/authorization/default_pundit_authorizer_spec.rb
+++ b/spec/jsonapi/authorization/default_pundit_authorizer_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe JSONAPI::Authorization::DefaultPunditAuthorizer do
 
   describe '#find' do
     subject(:method_call) do
-      -> { authorizer.find(source_record) }
+      -> { authorizer.find(source_class: source_record) }
     end
 
     context 'authorized for index? on record' do

--- a/spec/jsonapi/authorization/default_pundit_authorizer_spec.rb
+++ b/spec/jsonapi/authorization/default_pundit_authorizer_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe JSONAPI::Authorization::DefaultPunditAuthorizer do
 
   describe '#show_relationship' do
     subject(:method_call) do
-      -> { authorizer.show_relationship(source_record, related_record) }
+      -> { authorizer.show_relationship(source_record: source_record, related_record: related_record) }
     end
 
     context 'authorized for show? on source record' do
@@ -474,7 +474,13 @@ RSpec.describe JSONAPI::Authorization::DefaultPunditAuthorizer do
   describe '#replace_to_one_relationship' do
     let(:related_record) { User.new }
     subject(:method_call) do
-      -> { authorizer.replace_to_one_relationship(source_record, related_record, :author) }
+      -> {
+        authorizer.replace_to_one_relationship(
+          source_record: source_record,
+          new_related_record: related_record,
+          relationship_type: :author
+        )
+      }
     end
 
     context 'authorized for replace_<type>? and update? on record' do

--- a/spec/jsonapi/authorization/default_pundit_authorizer_spec.rb
+++ b/spec/jsonapi/authorization/default_pundit_authorizer_spec.rb
@@ -129,7 +129,12 @@ RSpec.describe JSONAPI::Authorization::DefaultPunditAuthorizer do
 
   describe '#show_related_resource' do
     subject(:method_call) do
-      -> { authorizer.show_related_resource(source_record, related_record) }
+      lambda do
+        authorizer.show_related_resource(
+          source_record: source_record,
+          related_record: related_record
+        )
+      end
     end
 
     context 'authorized for show? on source record' do

--- a/spec/jsonapi/authorization/default_pundit_authorizer_spec.rb
+++ b/spec/jsonapi/authorization/default_pundit_authorizer_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe JSONAPI::Authorization::DefaultPunditAuthorizer do
   fixtures :all
 
   let(:source_record) { Article.new }
-  let(:authorizer) { described_class.new({}) }
+  let(:authorizer) { described_class.new(context: {}) }
 
   shared_examples_for :update_singular_fallback do |related_record_method|
     context 'authorized for update? on related record' do

--- a/spec/jsonapi/authorization/default_pundit_authorizer_spec.rb
+++ b/spec/jsonapi/authorization/default_pundit_authorizer_spec.rb
@@ -212,7 +212,12 @@ RSpec.describe JSONAPI::Authorization::DefaultPunditAuthorizer do
       end
 
       subject(:method_call) do
-        -> { authorizer.replace_fields(source_record, related_records_with_context) }
+        lambda do
+          authorizer.replace_fields(
+            source_record: source_record,
+            related_records_with_context: related_records_with_context
+          )
+        end
       end
 
       context 'authorized for replace_<type>? and authorized for update? on source record' do
@@ -258,7 +263,12 @@ RSpec.describe JSONAPI::Authorization::DefaultPunditAuthorizer do
       end
 
       subject(:method_call) do
-        -> { authorizer.replace_fields(source_record, related_records_with_context) }
+        lambda do
+          authorizer.replace_fields(
+            source_record: source_record,
+            related_records_with_context: related_records_with_context
+          )
+        end
       end
 
       context 'authorized for remove_<type>? and authorized for update? on source record' do
@@ -305,7 +315,12 @@ RSpec.describe JSONAPI::Authorization::DefaultPunditAuthorizer do
       end
 
       subject(:method_call) do
-        -> { authorizer.replace_fields(source_record, related_records_with_context) }
+        lambda do
+          authorizer.replace_fields(
+            source_record: source_record,
+            related_records_with_context: related_records_with_context
+          )
+        end
       end
 
       context 'authorized for update? on source record and related records is empty' do
@@ -366,7 +381,12 @@ RSpec.describe JSONAPI::Authorization::DefaultPunditAuthorizer do
       end
       let(:source_class) { source_record.class }
       subject(:method_call) do
-        -> { authorizer.create_resource(source_class, related_records_with_context) }
+        lambda do
+          authorizer.create_resource(
+            source_class: source_class,
+            related_records_with_context: related_records_with_context
+          )
+        end
       end
 
       context 'authorized for create? and authorized for create_with_<type>? on source class' do
@@ -413,7 +433,12 @@ RSpec.describe JSONAPI::Authorization::DefaultPunditAuthorizer do
       end
       let(:source_class) { source_record.class }
       subject(:method_call) do
-        -> { authorizer.create_resource(source_class, related_records_with_context) }
+        lambda do
+          authorizer.create_resource(
+            source_class: source_class,
+            related_records_with_context: related_records_with_context
+          )
+        end
       end
 
       context 'authorized for create? on source class and related records is empty' do
@@ -528,7 +553,13 @@ RSpec.describe JSONAPI::Authorization::DefaultPunditAuthorizer do
   describe '#create_to_many_relationship' do
     let(:related_records) { Array.new(3) { Comment.new } }
     subject(:method_call) do
-      -> { authorizer.create_to_many_relationship(source_record, related_records, :comments) }
+      lambda do
+        authorizer.create_to_many_relationship(
+          source_record: source_record,
+          new_related_records: related_records,
+          relationship_type: :comments
+        )
+      end
     end
 
     context 'authorized for add_to_<type>? and update? on record' do
@@ -568,7 +599,13 @@ RSpec.describe JSONAPI::Authorization::DefaultPunditAuthorizer do
     let(:article) { articles(:article_with_comments) }
     let(:new_comments) { Array.new(3) { Comment.new } }
     subject(:method_call) do
-      -> { authorizer.replace_to_many_relationship(article, new_comments, :comments) }
+      lambda do
+        authorizer.replace_to_many_relationship(
+          source_record: article,
+          new_related_records: new_comments,
+          relationship_type: :comments
+        )
+      end
     end
 
     context 'authorized for replace_<type>? and update? on record' do
@@ -608,7 +645,13 @@ RSpec.describe JSONAPI::Authorization::DefaultPunditAuthorizer do
     let(:article) { articles(:article_with_comments) }
     let(:comments_to_remove) { article.comments.limit(2) }
     subject(:method_call) do
-      -> { authorizer.remove_to_many_relationship(article, comments_to_remove, :comments) }
+      lambda do
+        authorizer.remove_to_many_relationship(
+          source_record: article,
+          related_records: comments_to_remove,
+          relationship_type: :comments
+        )
+      end
     end
 
     context 'authorized for remove_from_<type>? and article? on article' do
@@ -646,7 +689,11 @@ RSpec.describe JSONAPI::Authorization::DefaultPunditAuthorizer do
 
   describe '#remove_to_one_relationship' do
     subject(:method_call) do
-      -> { authorizer.remove_to_one_relationship(source_record, :author) }
+      lambda do
+        authorizer.remove_to_one_relationship(
+          source_record: source_record, relationship_type: :author
+        )
+      end
     end
 
     context 'authorized for remove_<type>? and article? on record' do
@@ -686,7 +733,11 @@ RSpec.describe JSONAPI::Authorization::DefaultPunditAuthorizer do
     let(:record_class) { Article }
     let(:source_record) { Comment.new }
     subject(:method_call) do
-      -> { authorizer.include_has_many_resource(source_record, record_class) }
+      lambda do
+        authorizer.include_has_many_resource(
+          source_record: source_record, record_class: record_class
+        )
+      end
     end
 
     context 'authorized for index? on record class' do
@@ -704,7 +755,12 @@ RSpec.describe JSONAPI::Authorization::DefaultPunditAuthorizer do
     let(:related_record) { Article.new }
     let(:source_record) { Comment.new }
     subject(:method_call) do
-      -> { authorizer.include_has_one_resource(source_record, related_record) }
+      lambda do
+        authorizer.include_has_one_resource(
+          source_record: source_record,
+          related_record: related_record
+        )
+      end
     end
 
     context 'authorized for show? on record' do

--- a/spec/requests/included_resources_spec.rb
+++ b/spec/requests/included_resources_spec.rb
@@ -348,7 +348,7 @@ RSpec.describe 'including resources alongside normal operations', type: :request
     let(:article_policy_scope) { Article.where(id: article.id) }
 
     subject(:last_response) { get("/articles/#{article.external_id}/articles?include=#{include_query}") }
-    let!(:chained_authorizer) { allow_operation('show_related_resources', article) }
+    let!(:chained_authorizer) { allow_operation('show_related_resources', source_record: article) }
 
     include_examples :include_directive_tests
   end

--- a/spec/requests/included_resources_spec.rb
+++ b/spec/requests/included_resources_spec.rb
@@ -365,7 +365,7 @@ RSpec.describe 'including resources alongside normal operations', type: :request
     }
 
     subject(:last_response) { get("/articles/#{article.external_id}/article?include=#{include_query}") }
-    let!(:chained_authorizer) { allow_operation('show_related_resource', article, article) }
+    let!(:chained_authorizer) { allow_operation('show_related_resource', source_record: article, related_record: article) }
 
     include_examples :include_directive_tests
   end

--- a/spec/requests/included_resources_spec.rb
+++ b/spec/requests/included_resources_spec.rb
@@ -218,7 +218,7 @@ RSpec.describe 'including resources alongside normal operations', type: :request
     }
 
     subject(:last_response) { get("/articles/#{article.external_id}?include=#{include_query}") }
-    let!(:chained_authorizer) { allow_operation('show', article) }
+    let!(:chained_authorizer) { allow_operation('show', source_record: article) }
 
     include_examples :include_directive_tests
   end

--- a/spec/requests/included_resources_spec.rb
+++ b/spec/requests/included_resources_spec.rb
@@ -34,13 +34,27 @@ RSpec.describe 'including resources alongside normal operations', type: :request
       let(:comments_policy_scope) { Comment.all }
 
       context 'unauthorized for include_has_many_resource for Comment' do
-        before { disallow_operation('include_has_many_resource', an_instance_of(Article), Comment, authorizer: chained_authorizer) }
+        before {
+          disallow_operation(
+            'include_has_many_resource',
+            source_record: an_instance_of(Article),
+            record_class: Comment,
+            authorizer: chained_authorizer
+          )
+        }
 
         it { is_expected.to be_forbidden }
       end
 
       context 'authorized for include_has_many_resource for Comment' do
-        before { allow_operation('include_has_many_resource', an_instance_of(Article), Comment, authorizer: chained_authorizer) }
+        before {
+          allow_operation(
+            'include_has_many_resource',
+            source_record: an_instance_of(Article),
+            record_class: Comment,
+            authorizer: chained_authorizer
+          )
+        }
 
         it { is_expected.to be_successful }
 
@@ -57,13 +71,27 @@ RSpec.describe 'including resources alongside normal operations', type: :request
       let(:include_query) { 'author' }
 
       context 'unauthorized for include_has_one_resource for article.author' do
-        before { disallow_operation('include_has_one_resource', an_instance_of(Article), an_instance_of(User), authorizer: chained_authorizer) }
+        before {
+          disallow_operation(
+            'include_has_one_resource',
+            source_record: an_instance_of(Article),
+            related_record: an_instance_of(User),
+            authorizer: chained_authorizer
+          )
+        }
 
         it { is_expected.to be_forbidden }
       end
 
       context 'authorized for include_has_one_resource for article.author' do
-        before { allow_operation('include_has_one_resource', an_instance_of(Article), an_instance_of(User), authorizer: chained_authorizer) }
+        before {
+          allow_operation(
+            'include_has_one_resource',
+            source_record: an_instance_of(Article),
+            related_record: an_instance_of(User),
+            authorizer: chained_authorizer
+          )
+        }
 
         it { is_expected.to be_successful }
 
@@ -80,7 +108,12 @@ RSpec.describe 'including resources alongside normal operations', type: :request
 
       context 'unauthorized for include_has_one_resource for article.author' do
         before do
-          disallow_operation('include_has_one_resource', an_instance_of(Article), an_instance_of(User), authorizer: chained_authorizer)
+          disallow_operation(
+            'include_has_one_resource',
+            source_record: an_instance_of(Article),
+            related_record: an_instance_of(User),
+            authorizer: chained_authorizer
+          )
         end
 
         it { is_expected.to be_forbidden }
@@ -88,8 +121,8 @@ RSpec.describe 'including resources alongside normal operations', type: :request
 
       context 'unauthorized for include_has_many_resource for Comment' do
         before do
-          allow_operation('include_has_one_resource', an_instance_of(Article), an_instance_of(User), authorizer: chained_authorizer)
-          disallow_operation('include_has_many_resource', an_instance_of(Article), Comment, authorizer: chained_authorizer)
+          allow_operation('include_has_one_resource', source_record: an_instance_of(Article), related_record: an_instance_of(User), authorizer: chained_authorizer)
+          disallow_operation('include_has_many_resource', source_record: an_instance_of(Article), record_class: Comment, authorizer: chained_authorizer)
         end
 
         it { is_expected.to be_forbidden }
@@ -97,8 +130,8 @@ RSpec.describe 'including resources alongside normal operations', type: :request
 
       context 'authorized for both operations' do
         before do
-          allow_operation('include_has_one_resource', an_instance_of(Article), an_instance_of(User), authorizer: chained_authorizer)
-          allow_operation('include_has_many_resource', an_instance_of(Article), Comment, authorizer: chained_authorizer)
+          allow_operation('include_has_one_resource', source_record: an_instance_of(Article), related_record: an_instance_of(User), authorizer: chained_authorizer)
+          allow_operation('include_has_many_resource', source_record: an_instance_of(Article), record_class: Comment, authorizer: chained_authorizer)
         end
 
         it { is_expected.to be_successful }
@@ -122,22 +155,29 @@ RSpec.describe 'including resources alongside normal operations', type: :request
       let(:include_query) { 'author.comments' }
 
       context 'unauthorized for first relationship' do
-        before { disallow_operation('include_has_one_resource', an_instance_of(Article), an_instance_of(User), authorizer: chained_authorizer) }
+        before {
+          disallow_operation(
+            'include_has_one_resource',
+            source_record: an_instance_of(Article),
+            related_record: an_instance_of(User),
+            authorizer: chained_authorizer
+          )
+        }
 
         it { is_expected.to be_forbidden }
       end
 
       context 'authorized for first relationship' do
-        before { allow_operation('include_has_one_resource', an_instance_of(Article), an_instance_of(User), authorizer: chained_authorizer) }
+        before { allow_operation('include_has_one_resource', source_record: an_instance_of(Article), related_record: an_instance_of(User), authorizer: chained_authorizer) }
 
         context 'unauthorized for second relationship' do
-          before { disallow_operation('include_has_many_resource', an_instance_of(User), Comment, authorizer: chained_authorizer) }
+          before { disallow_operation('include_has_many_resource', source_record: an_instance_of(User), record_class: Comment, authorizer: chained_authorizer) }
 
           it { is_expected.to be_forbidden }
         end
 
         context 'authorized for second relationship' do
-          before { allow_operation('include_has_many_resource', an_instance_of(User), Comment, authorizer: chained_authorizer) }
+          before { allow_operation('include_has_many_resource', source_record: an_instance_of(User), record_class: Comment, authorizer: chained_authorizer) }
 
           it { is_expected.to be_successful }
 
@@ -172,13 +212,13 @@ RSpec.describe 'including resources alongside normal operations', type: :request
         let(:include_query) { 'empty-articles.comments' }
 
         context 'unauthorized for first relationship' do
-          before { disallow_operation('include_has_many_resource', an_instance_of(Article), Article, authorizer: chained_authorizer) }
+          before { disallow_operation('include_has_many_resource', source_record: an_instance_of(Article), record_class: Article, authorizer: chained_authorizer) }
 
           it { is_expected.to be_forbidden }
         end
 
         context 'authorized for first relationship' do
-          before { allow_operation('include_has_many_resource', an_instance_of(Article), Article, authorizer: chained_authorizer) }
+          before { allow_operation('include_has_many_resource', source_record: an_instance_of(Article), record_class: Article, authorizer: chained_authorizer) }
 
           it { is_expected.to be_successful }
         end
@@ -247,7 +287,7 @@ RSpec.describe 'including resources alongside normal operations', type: :request
       EOS
     end
     subject(:last_response) { patch("/articles/#{article.external_id}?include=#{include_query}", json) }
-    let!(:chained_authorizer) { allow_operation('replace_fields', article, []) }
+    let!(:chained_authorizer) { allow_operation('replace_fields', source_record: article, related_records_with_context: []) }
 
     include_examples :include_directive_tests
 
@@ -319,7 +359,11 @@ RSpec.describe 'including resources alongside normal operations', type: :request
 
     subject(:last_response) { post("/articles?include=#{include_query}", json) }
     let!(:chained_authorizer) do
-      allow_operation('create_resource', Article, related_records_with_context)
+      allow_operation(
+        'create_resource',
+        source_class: Article,
+        related_records_with_context: related_records_with_context
+      )
     end
 
     include_examples :include_directive_tests

--- a/spec/requests/included_resources_spec.rb
+++ b/spec/requests/included_resources_spec.rb
@@ -188,7 +188,7 @@ RSpec.describe 'including resources alongside normal operations', type: :request
 
   describe 'GET /articles' do
     subject(:last_response) { get("/articles?include=#{include_query}") }
-    let!(:chained_authorizer) { allow_operation('find', Article) }
+    let!(:chained_authorizer) { allow_operation('find', source_class: Article) }
 
     let(:article) {
       Article.create(

--- a/spec/requests/related_resources_operations_spec.rb
+++ b/spec/requests/related_resources_operations_spec.rb
@@ -59,12 +59,12 @@ RSpec.describe 'Related resources operations', type: :request do
     let(:policy_scope) { Article.all }
 
     context 'unauthorized for show_related_resource' do
-      before { disallow_operation('show_related_resource', article, article.author) }
+      before { disallow_operation('show_related_resource', source_record: article, related_record: article.author) }
       it { is_expected.to be_forbidden }
     end
 
     context 'authorized for show_related_resource' do
-      before { allow_operation('show_related_resource', article, article.author) }
+      before { allow_operation('show_related_resource', source_record: article, related_record: article.author) }
 
       # If this happens in real life, it's mostly a bug. We want to document the
       # behaviour in that case anyway, as it might be surprising.

--- a/spec/requests/related_resources_operations_spec.rb
+++ b/spec/requests/related_resources_operations_spec.rb
@@ -31,12 +31,12 @@ RSpec.describe 'Related resources operations', type: :request do
     end
 
     context 'unauthorized for show_related_resources' do
-      before { disallow_operation('show_related_resources', article) }
+      before { disallow_operation('show_related_resources', source_record: article) }
       it { is_expected.to be_forbidden }
     end
 
     context 'authorized for show_related_resources' do
-      before { allow_operation('show_related_resources', article) }
+      before { allow_operation('show_related_resources', source_record: article) }
       it { is_expected.to be_ok }
 
       # If this happens in real life, it's mostly a bug. We want to document the

--- a/spec/requests/relationship_operations_spec.rb
+++ b/spec/requests/relationship_operations_spec.rb
@@ -29,12 +29,12 @@ RSpec.describe 'Relationship operations', type: :request do
     subject(:last_response) { get("/articles/#{article.external_id}/relationships/comments") }
 
     context 'unauthorized for show_relationship' do
-      before { disallow_operation('show_relationship', {source_record: article, related_record: nil}) }
+      before { disallow_operation('show_relationship', source_record: article, related_record: nil) }
       it { is_expected.to be_forbidden }
     end
 
     context 'authorized for show_relationship' do
-      before { allow_operation('show_relationship', {source_record: article, related_record: nil}) }
+      before { allow_operation('show_relationship', source_record: article, related_record: nil) }
       it { is_expected.to be_ok }
 
       # If this happens in real life, it's mostly a bug. We want to document the
@@ -289,8 +289,11 @@ RSpec.describe 'Relationship operations', type: :request do
 
       context 'unauthorized for replace_to_one_relationship' do
         before {
-          disallow_operation('replace_to_one_relationship',
-            source_record: tag, new_related_record: new_taggable, relationship_type: :taggable
+          disallow_operation(
+            'replace_to_one_relationship',
+            source_record: tag,
+            new_related_record: new_taggable,
+            relationship_type: :taggable
           )
         }
         it { is_expected.to be_forbidden }
@@ -298,11 +301,12 @@ RSpec.describe 'Relationship operations', type: :request do
 
       context 'authorized for replace_to_one_relationship' do
         before {
-          allow_operation('replace_to_one_relationship',
+          allow_operation(
+            'replace_to_one_relationship',
             source_record: tag,
             new_related_record: new_taggable,
             relationship_type: :taggable
-          ) 
+          )
         }
         it { is_expected.to be_successful }
 

--- a/spec/requests/relationship_operations_spec.rb
+++ b/spec/requests/relationship_operations_spec.rb
@@ -29,12 +29,12 @@ RSpec.describe 'Relationship operations', type: :request do
     subject(:last_response) { get("/articles/#{article.external_id}/relationships/comments") }
 
     context 'unauthorized for show_relationship' do
-      before { disallow_operation('show_relationship', article, nil) }
+      before { disallow_operation('show_relationship', {source_record: article, related_record: nil}) }
       it { is_expected.to be_forbidden }
     end
 
     context 'authorized for show_relationship' do
-      before { allow_operation('show_relationship', article, nil) }
+      before { allow_operation('show_relationship', {source_record: article, related_record: nil}) }
       it { is_expected.to be_ok }
 
       # If this happens in real life, it's mostly a bug. We want to document the
@@ -58,12 +58,12 @@ RSpec.describe 'Relationship operations', type: :request do
     let(:policy_scope) { Article.all }
 
     context 'unauthorized for show_relationship' do
-      before { disallow_operation('show_relationship', article, article.author) }
+      before { disallow_operation('show_relationship', source_record: article, related_record: article.author) }
       it { is_expected.to be_forbidden }
     end
 
     context 'authorized for show_relationship' do
-      before { allow_operation('show_relationship', article, article.author) }
+      before { allow_operation('show_relationship', source_record: article, related_record: article.author) }
       it { is_expected.to be_ok }
 
       # If this happens in real life, it's mostly a bug. We want to document the
@@ -206,12 +206,12 @@ RSpec.describe 'Relationship operations', type: :request do
       end
 
       context 'unauthorized for replace_to_one_relationship' do
-        before { disallow_operation('replace_to_one_relationship', article, new_author, :author) }
+        before { disallow_operation('replace_to_one_relationship', source_record: article, new_related_record: new_author, relationship_type: :author) }
         it { is_expected.to be_forbidden }
       end
 
       context 'authorized for replace_to_one_relationship' do
-        before { allow_operation('replace_to_one_relationship', article, new_author, :author) }
+        before { allow_operation('replace_to_one_relationship', source_record: article, new_related_record: new_author, relationship_type: :author) }
         it { is_expected.to be_successful }
 
         context 'limited by policy scope on author', skip: 'DISCUSS' do
@@ -288,12 +288,22 @@ RSpec.describe 'Relationship operations', type: :request do
       end
 
       context 'unauthorized for replace_to_one_relationship' do
-        before { disallow_operation('replace_to_one_relationship', tag, new_taggable, :taggable) }
+        before {
+          disallow_operation('replace_to_one_relationship',
+            source_record: tag, new_related_record: new_taggable, relationship_type: :taggable
+          )
+        }
         it { is_expected.to be_forbidden }
       end
 
       context 'authorized for replace_to_one_relationship' do
-        before { allow_operation('replace_to_one_relationship', tag, new_taggable, :taggable) }
+        before {
+          allow_operation('replace_to_one_relationship',
+            source_record: tag,
+            new_related_record: new_taggable,
+            relationship_type: :taggable
+          ) 
+        }
         it { is_expected.to be_successful }
 
         context 'limited by policy scope on taggable', skip: 'DISCUSS' do

--- a/spec/requests/relationship_operations_spec.rb
+++ b/spec/requests/relationship_operations_spec.rb
@@ -96,12 +96,26 @@ RSpec.describe 'Relationship operations', type: :request do
     end
 
     context 'unauthorized for create_to_many_relationship' do
-      before { disallow_operation('create_to_many_relationship', article, new_comments, :comments) }
+      before {
+        disallow_operation(
+          'create_to_many_relationship',
+          source_record: article,
+          new_related_records: new_comments,
+          relationship_type: :comments
+        )
+      }
       it { is_expected.to be_forbidden }
     end
 
     context 'authorized for create_to_many_relationship' do
-      before { allow_operation('create_to_many_relationship', article, new_comments, :comments) }
+      before {
+        allow_operation(
+          'create_to_many_relationship',
+          source_record: article,
+          new_related_records: new_comments,
+          relationship_type: :comments
+        )
+      }
       it { is_expected.to be_successful }
 
       context 'limited by policy scope on comments' do
@@ -141,7 +155,7 @@ RSpec.describe 'Relationship operations', type: :request do
 
     context 'unauthorized for replace_to_many_relationship' do
       before do
-        disallow_operation('replace_to_many_relationship', article, new_comments, :comments)
+        disallow_operation('replace_to_many_relationship', source_record: article, new_related_records: new_comments, relationship_type: :comments)
       end
 
       it { is_expected.to be_forbidden }
@@ -150,7 +164,7 @@ RSpec.describe 'Relationship operations', type: :request do
     context 'authorized for replace_to_many_relationship' do
       context 'not limited by policy scopes' do
         before do
-          allow_operation('replace_to_many_relationship', article, new_comments, :comments)
+          allow_operation('replace_to_many_relationship', source_record: article, new_related_records: new_comments, relationship_type: :comments)
         end
 
         it { is_expected.to be_successful }
@@ -159,7 +173,7 @@ RSpec.describe 'Relationship operations', type: :request do
       context 'limited by policy scope on comments' do
         let(:comments_scope) { Comment.none }
         before do
-          allow_operation('replace_to_many_relationship', article, new_comments, :comments)
+          allow_operation('replace_to_many_relationship', source_record: article, new_related_records: new_comments, relationship_type: :comments)
         end
 
         it do
@@ -172,7 +186,12 @@ RSpec.describe 'Relationship operations', type: :request do
       # behaviour in that case anyway, as it might be surprising.
       context 'limited by policy scope on articles' do
         before do
-          allow_operation('replace_to_many_relationship', article, new_comments, :comments)
+          allow_operation(
+            'replace_to_many_relationship',
+            source_record: article,
+            new_related_records: new_comments,
+            relationship_type: :comments
+          )
         end
         let(:policy_scope) { Article.where.not(id: article.id) }
         it { is_expected.to be_not_found }
@@ -236,12 +255,12 @@ RSpec.describe 'Relationship operations', type: :request do
       let(:json) { '{ "data": null }' }
 
       context 'unauthorized for remove_to_one_relationship' do
-        before { disallow_operation('remove_to_one_relationship', article, :author) }
+        before { disallow_operation('remove_to_one_relationship', source_record: article, relationship_type: :author) }
         it { is_expected.to be_forbidden }
       end
 
       context 'authorized for remove_to_one_relationship' do
-        before { allow_operation('remove_to_one_relationship', article, :author) }
+        before { allow_operation('remove_to_one_relationship', source_record: article, relationship_type: :author) }
         it { is_expected.to be_successful }
 
         context 'limited by policy scope on author', skip: 'DISCUSS' do
@@ -330,12 +349,12 @@ RSpec.describe 'Relationship operations', type: :request do
       let(:json) { '{ "data": null }' }
 
       context 'unauthorized for remove_to_one_relationship' do
-        before { disallow_operation('remove_to_one_relationship', tag, :taggable) }
+        before { disallow_operation('remove_to_one_relationship', source_record: tag, relationship_type: :taggable) }
         it { is_expected.to be_forbidden }
       end
 
       context 'authorized for remove_to_one_relationship' do
-        before { allow_operation('remove_to_one_relationship', tag, :taggable) }
+        before { allow_operation('remove_to_one_relationship', source_record: tag, relationship_type: :taggable) }
         it { is_expected.to be_successful }
 
         context 'limited by policy scope on taggable', skip: 'DISCUSS' do
@@ -378,9 +397,9 @@ RSpec.describe 'Relationship operations', type: :request do
       before do
         disallow_operation(
           'remove_to_many_relationship',
-          article,
-          [comments_to_remove.first, comments_to_remove.second],
-          :comments
+          source_record: article,
+          related_records: [comments_to_remove.first, comments_to_remove.second],
+          relationship_type: :comments
         )
       end
 
@@ -392,9 +411,9 @@ RSpec.describe 'Relationship operations', type: :request do
         before do
           allow_operation(
             'remove_to_many_relationship',
-            article,
-            [comments_to_remove.first, comments_to_remove.second],
-            :comments
+            source_record: article,
+            related_records: [comments_to_remove.first, comments_to_remove.second],
+            relationship_type: :comments
           )
         end
 
@@ -404,7 +423,7 @@ RSpec.describe 'Relationship operations', type: :request do
       context 'limited by policy scope on comments' do
         let(:comments_scope) { Comment.none }
         before do
-          allow_operation('remove_to_many_relationship', article, [], :comments)
+          allow_operation('remove_to_many_relationship', source_record: article, related_records: [], relationship_type: :comments)
         end
 
         # This succeeds because the request isn't actually able to try removing any comments
@@ -418,9 +437,9 @@ RSpec.describe 'Relationship operations', type: :request do
         before do
           allow_operation(
             'remove_to_many_relationship',
-            article,
-            [comments_to_remove.first, comments_to_remove.second],
-            :comments
+            source_record: article,
+            related_records: [comments_to_remove.first, comments_to_remove.second],
+            relationship_type: :comments
           )
         end
         let(:policy_scope) { Article.where.not(id: article.id) }
@@ -436,12 +455,12 @@ RSpec.describe 'Relationship operations', type: :request do
     let(:policy_scope) { Article.all }
 
     context 'unauthorized for remove_to_one_relationship' do
-      before { disallow_operation('remove_to_one_relationship', article, :author) }
+      before { disallow_operation('remove_to_one_relationship', source_record: article, relationship_type: :author) }
       it { is_expected.to be_forbidden }
     end
 
     context 'authorized for remove_to_one_relationship' do
-      before { allow_operation('remove_to_one_relationship', article, :author) }
+      before { allow_operation('remove_to_one_relationship', source_record: article, relationship_type: :author) }
       it { is_expected.to be_successful }
 
       # If this happens in real life, it's mostly a bug. We want to document the

--- a/spec/requests/resource_operations_spec.rb
+++ b/spec/requests/resource_operations_spec.rb
@@ -134,7 +134,7 @@ describe 'Resource operations', type: :request do
     let(:policy_scope) { Article.all }
 
     context 'unauthorized for remove_resource' do
-      before { disallow_operation('remove_resource', article) }
+      before { disallow_operation('remove_resource', source_record: article) }
 
       context 'not limited by policy scope' do
         it { is_expected.to be_forbidden }
@@ -147,7 +147,7 @@ describe 'Resource operations', type: :request do
     end
 
     context 'authorized for remove_resource' do
-      before { allow_operation('remove_resource', article) }
+      before { allow_operation('remove_resource', source_record: article) }
       it { is_expected.to be_successful }
 
       # If this happens in real life, it's mostly a bug. We want to document the

--- a/spec/requests/resource_operations_spec.rb
+++ b/spec/requests/resource_operations_spec.rb
@@ -44,7 +44,7 @@ describe 'Resource operations', type: :request do
     let(:policy_scope) { Article.all }
 
     context 'unauthorized for show' do
-      before { disallow_operation('show', article) }
+      before { disallow_operation('show', source_record: article) }
 
       context 'not limited by policy scope' do
         it { is_expected.to be_forbidden }
@@ -57,7 +57,7 @@ describe 'Resource operations', type: :request do
     end
 
     context 'authorized for show' do
-      before { allow_operation('show', article) }
+      before { allow_operation('show', source_record: article) }
       it { is_expected.to be_ok }
 
       # If this happens in real life, it's mostly a bug. We want to document the

--- a/spec/requests/resource_operations_spec.rb
+++ b/spec/requests/resource_operations_spec.rb
@@ -83,12 +83,12 @@ describe 'Resource operations', type: :request do
     end
 
     context 'unauthorized for create_resource' do
-      before { disallow_operation('create_resource', Article, []) }
+      before { disallow_operation('create_resource', source_class: Article, related_records_with_context: []) }
       it { is_expected.to be_forbidden }
     end
 
     context 'authorized for create_resource' do
-      before { allow_operation('create_resource', Article, []) }
+      before { allow_operation('create_resource', source_class: Article, related_records_with_context: []) }
       it { is_expected.to be_successful }
     end
   end
@@ -109,7 +109,7 @@ describe 'Resource operations', type: :request do
     let(:policy_scope) { Article.all }
 
     context 'authorized for replace_fields' do
-      before { allow_operation('replace_fields', article, []) }
+      before { allow_operation('replace_fields', source_record: article, related_records_with_context: []) }
       it { is_expected.to be_successful }
 
       context 'limited by policy scope' do
@@ -119,7 +119,7 @@ describe 'Resource operations', type: :request do
     end
 
     context 'unauthorized for replace_fields' do
-      before { disallow_operation('replace_fields', article, []) }
+      before { disallow_operation('replace_fields', source_record: article, related_records_with_context: []) }
       it { is_expected.to be_forbidden }
 
       context 'limited by policy scope' do

--- a/spec/requests/resource_operations_spec.rb
+++ b/spec/requests/resource_operations_spec.rb
@@ -22,12 +22,12 @@ describe 'Resource operations', type: :request do
     subject(:last_response) { get('/articles') }
 
     context 'unauthorized for find' do
-      before { disallow_operation('find', Article) }
+      before { disallow_operation('find', source_class: Article) }
       it { is_expected.to be_forbidden }
     end
 
     context 'authorized for find' do
-      before { allow_operation('find', Article) }
+      before { allow_operation('find', source_class: Article) }
       let(:policy_scope) { Article.where(id: article.id) }
 
       it { is_expected.to be_ok }

--- a/spec/requests/tricky_operations_spec.rb
+++ b/spec/requests/tricky_operations_spec.rb
@@ -47,14 +47,14 @@ RSpec.describe 'Tricky operations', type: :request do
 
     context 'authorized for create_resource on Comment and newly associated article' do
       let(:policy_scope) { Article.where(id: article.id) }
-      before { allow_operation('create_resource', Comment, related_records_with_context) }
+      before { allow_operation('create_resource', source_class: Comment, related_records_with_context: related_records_with_context) }
 
       it { is_expected.to be_successful }
     end
 
     context 'unauthorized for create_resource on Comment and newly associated article' do
       let(:policy_scope) { Article.where(id: article.id) }
-      before { disallow_operation('create_resource', Comment, related_records_with_context) }
+      before { disallow_operation('create_resource', source_class: Comment, related_records_with_context: related_records_with_context) }
 
       it { is_expected.to be_forbidden }
     end
@@ -98,14 +98,14 @@ RSpec.describe 'Tricky operations', type: :request do
 
     context 'authorized for create_resource on Article and newly associated comments' do
       let(:policy_scope) { Article.where(id: "new-article-id") }
-      before { allow_operation('create_resource', Article, related_records_with_context) }
+      before { allow_operation('create_resource', source_class: Article, related_records_with_context: related_records_with_context) }
 
       it { is_expected.to be_successful }
     end
 
     context 'unauthorized for create_resource on Article and newly associated comments' do
       let(:policy_scope) { Article.where(id: "new-article-id") }
-      before { disallow_operation('create_resource', Article, related_records_with_context) }
+      before { disallow_operation('create_resource', source_class: Article, related_records_with_context: related_records_with_context) }
 
       it { is_expected.to be_forbidden }
     end
@@ -141,14 +141,14 @@ RSpec.describe 'Tricky operations', type: :request do
 
     context 'authorized for create_resource on Tag and newly associated article' do
       let(:policy_scope) { Article.where(id: article.id) }
-      before { allow_operation('create_resource', Tag, related_records_with_context) }
+      before { allow_operation('create_resource', source_class: Tag, related_records_with_context: related_records_with_context) }
 
       it { is_expected.to be_successful }
     end
 
     context 'unauthorized for create_resource on Tag and newly associated article' do
       let(:policy_scope) { Article.where(id: article.id) }
-      before { disallow_operation('create_resource', Tag, related_records_with_context) }
+      before { disallow_operation('create_resource', source_class: Tag, related_records_with_context: related_records_with_context) }
 
       it { is_expected.to be_forbidden }
     end
@@ -193,7 +193,7 @@ RSpec.describe 'Tricky operations', type: :request do
 
     context 'authorized for replace_fields on article and all new records' do
       context 'not limited by Comments policy scope' do
-        before { allow_operation('replace_fields', article, related_records_with_context) }
+        before { allow_operation('replace_fields', source_record: article, related_records_with_context: related_records_with_context) }
         it { is_expected.to be_successful }
       end
 
@@ -207,14 +207,14 @@ RSpec.describe 'Tricky operations', type: :request do
             records: []
           }]
         end
-        before { allow_operation('replace_fields', article, related_records_with_context) }
+        before { allow_operation('replace_fields', source_record: article, related_records_with_context: related_records_with_context) }
 
         it { is_expected.to be_successful }
       end
     end
 
     context 'unauthorized for replace_fields on article and all new records' do
-      before { disallow_operation('replace_fields', article, related_records_with_context) }
+      before { disallow_operation('replace_fields', source_record: article, related_records_with_context: related_records_with_context) }
 
       it { is_expected.to be_forbidden }
     end
@@ -239,8 +239,8 @@ RSpec.describe 'Tricky operations', type: :request do
     before do
       allow_operation(
         'replace_fields',
-        article,
-        [{ relation_type: :to_one, relation_name: :author, records: nil }]
+        source_record: article,
+        related_records_with_context: [{ relation_type: :to_one, relation_name: :author, records: nil }]
       )
     end
 

--- a/spec/support/authorization_stubs.rb
+++ b/spec/support/authorization_stubs.rb
@@ -2,22 +2,18 @@ module AuthorizationStubs
   AUTHORIZER_CLASS = JSONAPI::Authorization::DefaultPunditAuthorizer
 
   def allow_operation(operation, *args, authorizer: instance_double(AUTHORIZER_CLASS), **kwargs)
-    if kwargs.empty?
-      allow(authorizer).to receive(operation).with(*args).and_return(nil)
-    else
-      allow(authorizer).to receive(operation).with(*args, **kwargs).and_return(nil)
-    end
+    allow(authorizer).to receive(operation).tap {|x|
+      if kwargs.empty? then x.with(*args) else x.with(*args, **kwargs) end
+    }.and_return(nil)
 
     allow(AUTHORIZER_CLASS).to receive(:new).with(Hash).and_return(authorizer)
     authorizer
   end
 
   def disallow_operation(operation, *args, authorizer: instance_double(AUTHORIZER_CLASS), **kwargs)
-    if kwargs.empty?
-      allow(authorizer).to receive(operation).with(*args).and_raise(Pundit::NotAuthorizedError)
-    else
-      allow(authorizer).to receive(operation).with(*args, **kwargs).and_raise(Pundit::NotAuthorizedError)
-    end
+    allow(authorizer).to receive(operation).tap {|x|
+      if kwargs.empty? then x.with(*args) else x.with(*args, **kwargs) end
+    }.and_raise(Pundit::NotAuthorizedError)
 
     allow(AUTHORIZER_CLASS).to receive(:new).with(Hash).and_return(authorizer)
     authorizer

--- a/spec/support/authorization_stubs.rb
+++ b/spec/support/authorization_stubs.rb
@@ -1,15 +1,23 @@
 module AuthorizationStubs
   AUTHORIZER_CLASS = JSONAPI::Authorization::DefaultPunditAuthorizer
 
-  def allow_operation(operation, *args, authorizer: instance_double(AUTHORIZER_CLASS))
-    allow(authorizer).to receive(operation).with(*args).and_return(nil)
+  def allow_operation(operation, *args, authorizer: instance_double(AUTHORIZER_CLASS), **kwargs)
+    if kwargs.empty?
+      allow(authorizer).to receive(operation).with(*args).and_return(nil)
+    else
+      allow(authorizer).to receive(operation).with(*args, **kwargs).and_return(nil)
+    end
 
     allow(AUTHORIZER_CLASS).to receive(:new).with(Hash).and_return(authorizer)
     authorizer
   end
 
-  def disallow_operation(operation, *args, authorizer: instance_double(AUTHORIZER_CLASS))
-    allow(authorizer).to receive(operation).with(*args).and_raise(Pundit::NotAuthorizedError)
+  def disallow_operation(operation, *args, authorizer: instance_double(AUTHORIZER_CLASS), **kwargs)
+    if kwargs.empty?
+      allow(authorizer).to receive(operation).with(*args).and_raise(Pundit::NotAuthorizedError)
+    else
+      allow(authorizer).to receive(operation).with(*args, **kwargs).and_raise(Pundit::NotAuthorizedError)
+    end
 
     allow(AUTHORIZER_CLASS).to receive(:new).with(Hash).and_return(authorizer)
     authorizer

--- a/spec/support/authorization_stubs.rb
+++ b/spec/support/authorization_stubs.rb
@@ -1,19 +1,15 @@
 module AuthorizationStubs
   AUTHORIZER_CLASS = JSONAPI::Authorization::DefaultPunditAuthorizer
 
-  def allow_operation(operation, *args, authorizer: instance_double(AUTHORIZER_CLASS), **kwargs)
-    allow(authorizer).to receive(operation).tap {|x|
-      kwargs.empty? ? x.with(*args) : x.with(*args, **kwargs)
-    }.and_return(nil)
+  def allow_operation(operation, authorizer: instance_double(AUTHORIZER_CLASS), **kwargs)
+    allow(authorizer).to receive(operation).with(**kwargs).and_return(nil)
 
     allow(AUTHORIZER_CLASS).to receive(:new).with(context: kind_of(Hash)).and_return(authorizer)
     authorizer
   end
 
-  def disallow_operation(operation, *args, authorizer: instance_double(AUTHORIZER_CLASS), **kwargs)
-    allow(authorizer).to receive(operation).tap {|x|
-      kwargs.empty? ? x.with(*args) : x.with(*args, **kwargs)
-    }.and_raise(Pundit::NotAuthorizedError)
+  def disallow_operation(operation, authorizer: instance_double(AUTHORIZER_CLASS), **kwargs)
+    allow(authorizer).to receive(operation).with(**kwargs).and_raise(Pundit::NotAuthorizedError)
 
     allow(AUTHORIZER_CLASS).to receive(:new).with(context: kind_of(Hash)).and_return(authorizer)
     authorizer

--- a/spec/support/authorization_stubs.rb
+++ b/spec/support/authorization_stubs.rb
@@ -6,7 +6,7 @@ module AuthorizationStubs
       kwargs.empty? ? x.with(*args) : x.with(*args, **kwargs)
     }.and_return(nil)
 
-    allow(AUTHORIZER_CLASS).to receive(:new).with(Hash).and_return(authorizer)
+    allow(AUTHORIZER_CLASS).to receive(:new).with(context: kind_of(Hash)).and_return(authorizer)
     authorizer
   end
 
@@ -15,7 +15,7 @@ module AuthorizationStubs
       kwargs.empty? ? x.with(*args) : x.with(*args, **kwargs)
     }.and_raise(Pundit::NotAuthorizedError)
 
-    allow(AUTHORIZER_CLASS).to receive(:new).with(Hash).and_return(authorizer)
+    allow(AUTHORIZER_CLASS).to receive(:new).with(context: kind_of(Hash)).and_return(authorizer)
     authorizer
   end
 
@@ -25,6 +25,6 @@ module AuthorizationStubs
       allow(authorizer).to receive(operation).with(*args).and_return(nil)
     end
 
-    allow(AUTHORIZER_CLASS).to receive(:new).with(Hash).and_return(authorizer)
+    allow(AUTHORIZER_CLASS).to receive(:new).with(context: kind_of(Hash)).and_return(authorizer)
   end
 end

--- a/spec/support/authorization_stubs.rb
+++ b/spec/support/authorization_stubs.rb
@@ -3,7 +3,7 @@ module AuthorizationStubs
 
   def allow_operation(operation, *args, authorizer: instance_double(AUTHORIZER_CLASS), **kwargs)
     allow(authorizer).to receive(operation).tap {|x|
-      if kwargs.empty? then x.with(*args) else x.with(*args, **kwargs) end
+      kwargs.empty? ? x.with(*args) : x.with(*args, **kwargs)
     }.and_return(nil)
 
     allow(AUTHORIZER_CLASS).to receive(:new).with(Hash).and_return(authorizer)
@@ -12,7 +12,7 @@ module AuthorizationStubs
 
   def disallow_operation(operation, *args, authorizer: instance_double(AUTHORIZER_CLASS), **kwargs)
     allow(authorizer).to receive(operation).tap {|x|
-      if kwargs.empty? then x.with(*args) else x.with(*args, **kwargs) end
+      kwargs.empty? ? x.with(*args) : x.with(*args, **kwargs)
     }.and_raise(Pundit::NotAuthorizedError)
 
     allow(AUTHORIZER_CLASS).to receive(:new).with(Hash).and_return(authorizer)


### PR DESCRIPTION
I saw in #48 that help was wanted using keyword args for `JSONAPI::Authorization::DefaultPunditAuthorizer` so I've had a go at it. I've done 2 methods to see how it goes, and I'd like feedback to check I'm doing what you wanted before continuing. 

The only hard part I found was making the `AuthorizationStubs` helpers work with keyword args as well as splat args. I'm not entirely happy with how I solved that, so any thoughts on that would be great. To see why I've done that, try changing the stub method and re-run the tests and you'll find a lot of things start breaking in various places with wrong-number-of-argument errors and other fun things.