### PR TITLE
Mention JR 0.9 support in README in v1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Or install it yourself as:
 
 * `v0.6.x` supports JR `v0.7.x`
 * `v0.8.x` supports JR `v0.8.x`
+* `v1.0.0` alpha and beta releases support JR `v0.9.x`
 
 We aim to support the same Ruby and Ruby on Rails versions as `jsonapi-resources` does. If that's not the case, please [open an issue][issues].
 


### PR DESCRIPTION
There had been confusion in the past regarding 0.9 support. Might as well mention it in the README.

Re: https://github.com/venuu/jsonapi-authorization/issues/91