### PR TITLE
Relax jsonapi-resources to ~> 0.9 in tests

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -1,47 +1,47 @@
 appraise 'rails-4-2 pundit-1' do
   gem 'rails', '4.2.0'
-  gem 'jsonapi-resources', '0.9'
+  gem 'jsonapi-resources', '~> 0.9'
   gem 'pundit', '~> 1.0'
 end
 
 appraise 'rails-5-0 pundit-1' do
   gem 'rails', '5.0.0'
-  gem 'jsonapi-resources', '0.9'
+  gem 'jsonapi-resources', '~> 0.9'
   gem 'pundit', '~> 1.0'
 end
 
 appraise 'rails-5-1 pundit-1' do
   gem "rails", "5.1.0"
-  gem 'jsonapi-resources', '0.9'
+  gem 'jsonapi-resources', '~> 0.9'
   gem 'pundit', '~> 1.0'
 end
 
 appraise 'rails-5-2 pundit-1' do
   gem 'rails', '5.2.0'
-  gem 'jsonapi-resources', '0.9'
+  gem 'jsonapi-resources', '~> 0.9'
   gem 'pundit', '~> 1.0'
 end
 
 appraise 'rails-4-2 pundit-2' do
   gem 'rails', '4.2.0'
-  gem 'jsonapi-resources', '0.9'
+  gem 'jsonapi-resources', '~> 0.9'
   gem 'pundit', '~> 2.0'
 end
 
 appraise 'rails-5-0 pundit-2' do
   gem 'rails', '5.0.0'
-  gem 'jsonapi-resources', '0.9'
+  gem 'jsonapi-resources', '~> 0.9'
   gem 'pundit', '~> 2.0'
 end
 
 appraise 'rails-5-1 pundit-2' do
   gem 'rails', '5.1.0'
-  gem 'jsonapi-resources', '0.9'
+  gem 'jsonapi-resources', '~> 0.9'
   gem 'pundit', '~> 2.0'
 end
 
 appraise 'rails-5-2 pundit-2' do
   gem 'rails', '5.2.0'
-  gem 'jsonapi-resources', '0.9'
+  gem 'jsonapi-resources', '~> 0.9'
   gem 'pundit', '~> 2.0'
 end

--- a/gemfiles/rails_4_2_pundit_1.gemfile
+++ b/gemfiles/rails_4_2_pundit_1.gemfile
@@ -3,7 +3,7 @@
 source "https://rubygems.org"
 
 gem "rails", "4.2.0"
-gem "jsonapi-resources", "0.9"
+gem "jsonapi-resources", "~> 0.9"
 gem "pundit", "~> 1.0"
 
 gemspec path: "../"

--- a/gemfiles/rails_4_2_pundit_2.gemfile
+++ b/gemfiles/rails_4_2_pundit_2.gemfile
@@ -3,7 +3,7 @@
 source "https://rubygems.org"
 
 gem "rails", "4.2.0"
-gem "jsonapi-resources", "0.9"
+gem "jsonapi-resources", "~> 0.9"
 gem "pundit", "~> 2.0"
 
 gemspec path: "../"

--- a/gemfiles/rails_5_0_pundit_1.gemfile
+++ b/gemfiles/rails_5_0_pundit_1.gemfile
@@ -3,7 +3,7 @@
 source "https://rubygems.org"
 
 gem "rails", "5.0.0"
-gem "jsonapi-resources", "0.9"
+gem "jsonapi-resources", "~> 0.9"
 gem "pundit", "~> 1.0"
 
 gemspec path: "../"

--- a/gemfiles/rails_5_0_pundit_2.gemfile
+++ b/gemfiles/rails_5_0_pundit_2.gemfile
@@ -3,7 +3,7 @@
 source "https://rubygems.org"
 
 gem "rails", "5.0.0"
-gem "jsonapi-resources", "0.9"
+gem "jsonapi-resources", "~> 0.9"
 gem "pundit", "~> 2.0"
 
 gemspec path: "../"

--- a/gemfiles/rails_5_1_pundit_1.gemfile
+++ b/gemfiles/rails_5_1_pundit_1.gemfile
@@ -3,7 +3,7 @@
 source "https://rubygems.org"
 
 gem "rails", "5.1.0"
-gem "jsonapi-resources", "0.9"
+gem "jsonapi-resources", "~> 0.9"
 gem "pundit", "~> 1.0"
 
 gemspec path: "../"

--- a/gemfiles/rails_5_1_pundit_2.gemfile
+++ b/gemfiles/rails_5_1_pundit_2.gemfile
@@ -3,7 +3,7 @@
 source "https://rubygems.org"
 
 gem "rails", "5.1.0"
-gem "jsonapi-resources", "0.9"
+gem "jsonapi-resources", "~> 0.9"
 gem "pundit", "~> 2.0"
 
 gemspec path: "../"

--- a/gemfiles/rails_5_2_pundit_1.gemfile
+++ b/gemfiles/rails_5_2_pundit_1.gemfile
@@ -3,7 +3,7 @@
 source "https://rubygems.org"
 
 gem "rails", "5.2.0"
-gem "jsonapi-resources", "0.9"
+gem "jsonapi-resources", "~> 0.9"
 gem "pundit", "~> 1.0"
 
 gemspec path: "../"

--- a/gemfiles/rails_5_2_pundit_2.gemfile
+++ b/gemfiles/rails_5_2_pundit_2.gemfile
@@ -3,7 +3,7 @@
 source "https://rubygems.org"
 
 gem "rails", "5.2.0"
-gem "jsonapi-resources", "0.9"
+gem "jsonapi-resources", "~> 0.9"
 gem "pundit", "~> 2.0"
 
 gemspec path: "../"

--- a/spec/dummy/app/controllers/taggable_controller.rb
+++ b/spec/dummy/app/controllers/taggable_controller.rb
@@ -1,0 +1,6 @@
+# http://jsonapi-resources.com/v0.9/guide/resources.html#Relationships
+#
+# > The polymorphic relationship will require the resource
+# > and controller to exist, although routing to them will
+# > cause an error.
+class TaggablesController < JSONAPI::ResourceController; end

--- a/spec/dummy/app/resources/taggable_resource.rb
+++ b/spec/dummy/app/resources/taggable_resource.rb
@@ -1,0 +1,6 @@
+# http://jsonapi-resources.com/v0.9/guide/resources.html#Relationships
+#
+# > The polymorphic relationship will require the resource
+# > and controller to exist, although routing to them will
+# > cause an error.
+class TaggableResource < JSONAPI::Resource; end

--- a/spec/dummy/app/resources/taggable_resource.rb
+++ b/spec/dummy/app/resources/taggable_resource.rb
@@ -3,4 +3,9 @@
 # > The polymorphic relationship will require the resource
 # > and controller to exist, although routing to them will
 # > cause an error.
-class TaggableResource < JSONAPI::Resource; end
+class TaggableResource < JSONAPI::Resource
+  def self.verify_key(key, _context = nil)
+    # Allow a string key for polymorphic associations
+    key && String(key)
+  end
+end


### PR DESCRIPTION
This should make tests use the latest 0.9 release of `jsonapi-resources`, which at the time of writing, is v0.9.4: https://github.com/cerebris/jsonapi-resources/releases/tag/v0.9.4