### PR TITLE
Feature/check relationship policy

### DIFF
--- a/lib/jsonapi/authorization/authorizing_processor.rb
+++ b/lib/jsonapi/authorization/authorizing_processor.rb
@@ -109,7 +109,8 @@ module JSONAPI
         source_record = source_resource._model
 
         related_resource = source_resource.public_send(params[:relationship_type].to_sym)
-        related_class = related_resource.first.class
+        related_class = related_resource.first._model.class
+
 
         authorizer.show_related_resources(
           source_record: source_record, related_record_class: related_class

--- a/lib/jsonapi/authorization/authorizing_processor.rb
+++ b/lib/jsonapi/authorization/authorizing_processor.rb
@@ -108,11 +108,11 @@ module JSONAPI
 
         source_record = source_resource._model
 
-        related_resource = source_resource.public_send(params[:relationship_type].to_sym)
-        related_class = related_resource.first._model.class
+        related_resource_class = source_resource.class._relationsop(params[:relationship_type])
+        related_model_class = related_resource_class.class_name.safe_constantize
 
         authorizer.show_related_resources(
-          source_record: source_record, related_record_class: related_class
+          source_record: source_record, related_record_class: related_model_class
         )
       end
 

--- a/lib/jsonapi/authorization/authorizing_processor.rb
+++ b/lib/jsonapi/authorization/authorizing_processor.rb
@@ -101,12 +101,19 @@ module JSONAPI
       end
 
       def authorize_show_related_resources
-        source_record = params[:source_klass].find_by_key(
+        source_resource = params[:source_klass].find_by_key(
           params[:source_id],
           context: context
-        )._model
+        )
 
-        authorizer.show_related_resources(source_record: source_record)
+        source_record = source_resource._model
+
+        related_resource = source_resource.public_send(params[:relationship_type].to_sym)
+        related_class = related_resource.first.class
+
+        authorizer.show_related_resources(
+          source_record: source_record, related_record_class: related_class
+        )
       end
 
       def authorize_replace_fields

--- a/lib/jsonapi/authorization/authorizing_processor.rb
+++ b/lib/jsonapi/authorization/authorizing_processor.rb
@@ -111,7 +111,6 @@ module JSONAPI
         related_resource = source_resource.public_send(params[:relationship_type].to_sym)
         related_class = related_resource.first._model.class
 
-
         authorizer.show_related_resources(
           source_record: source_record, related_record_class: related_class
         )

--- a/lib/jsonapi/authorization/authorizing_processor.rb
+++ b/lib/jsonapi/authorization/authorizing_processor.rb
@@ -108,11 +108,8 @@ module JSONAPI
 
         source_record = source_resource._model
 
-        related_resource_class = source_resource.class._relationship(params[:relationship_type])
-        related_model_class = related_resource_class.class_name.safe_constantize
-
         authorizer.show_related_resources(
-          source_record: source_record, related_record_class: related_model_class
+          source_record: source_record, related_record_class: @resource_klass._model_class
         )
       end
 

--- a/lib/jsonapi/authorization/authorizing_processor.rb
+++ b/lib/jsonapi/authorization/authorizing_processor.rb
@@ -108,7 +108,7 @@ module JSONAPI
 
         source_record = source_resource._model
 
-        related_resource_class = source_resource.class._relationsop(params[:relationship_type])
+        related_resource_class = source_resource.class._relationship(params[:relationship_type])
         related_model_class = related_resource_class.class_name.safe_constantize
 
         authorizer.show_related_resources(

--- a/lib/jsonapi/authorization/default_pundit_authorizer.rb
+++ b/lib/jsonapi/authorization/default_pundit_authorizer.rb
@@ -77,8 +77,10 @@ module JSONAPI
       # ==== Parameters
       #
       # * +source_record+ - The record whose relationship is queried
-      def show_related_resources(source_record:)
+      # * +related_record_class+ - The associated record class to show
+      def show_related_resources(source_record:, related_record_class:)
         ::Pundit.authorize(user, source_record, 'show?')
+        ::Pundit.authorize(user, related_record_class, 'index?')
       end
 
       # <tt>PATCH /resources/:id</tt>

--- a/spec/jsonapi/authorization/default_pundit_authorizer_spec.rb
+++ b/spec/jsonapi/authorization/default_pundit_authorizer_spec.rb
@@ -185,18 +185,40 @@ RSpec.describe JSONAPI::Authorization::DefaultPunditAuthorizer do
   end
 
   describe '#show_related_resources' do
+    let(:related_record) { Comment.new }
+
     subject(:method_call) do
-      -> { authorizer.show_related_resources(source_record: source_record) }
+      -> { authorizer.show_related_resources(source_record: source_record, related_record_class: related_record) }
     end
 
-    context 'authorized for show? on record' do
+    context 'authorized for show? on source record' do
       before { allow_action(source_record, 'show?') }
-      it { is_expected.not_to raise_error }
+
+      context 'authorized for index? on related record' do
+        before { allow_action(related_record, 'index?') }
+        it { is_expected.not_to raise_error }
+      end
+
+      context 'unauthorized for index? on related record' do
+        before { disallow_action(related_record, 'index?') }
+        it { is_expected.to raise_error(::Pundit::NotAuthorizedError) }
+      end
+
+
     end
 
     context 'unauthorized for show? on record' do
       before { disallow_action(source_record, 'show?') }
-      it { is_expected.to raise_error(::Pundit::NotAuthorizedError) }
+
+      context 'authorized for index? on related record' do
+        before { allow_action(related_record, 'index?') }
+        it { is_expected.to raise_error(::Pundit::NotAuthorizedError) }
+      end
+
+      context 'unauthorized for index? on related record' do
+        before { disallow_action(related_record, 'index?') }
+        it { is_expected.to raise_error(::Pundit::NotAuthorizedError) }
+      end
     end
   end
 

--- a/spec/jsonapi/authorization/default_pundit_authorizer_spec.rb
+++ b/spec/jsonapi/authorization/default_pundit_authorizer_spec.rb
@@ -188,7 +188,11 @@ RSpec.describe JSONAPI::Authorization::DefaultPunditAuthorizer do
     let(:related_record) { Comment.new }
 
     subject(:method_call) do
-      -> { authorizer.show_related_resources(source_record: source_record, related_record_class: related_record) }
+      lambda {
+        authorizer.show_related_resources(source_record: source_record,
+                                          related_record_class: related_record
+      )
+      }
     end
 
     context 'authorized for show? on source record' do
@@ -203,8 +207,6 @@ RSpec.describe JSONAPI::Authorization::DefaultPunditAuthorizer do
         before { disallow_action(related_record, 'index?') }
         it { is_expected.to raise_error(::Pundit::NotAuthorizedError) }
       end
-
-
     end
 
     context 'unauthorized for show? on record' do

--- a/spec/requests/included_resources_spec.rb
+++ b/spec/requests/included_resources_spec.rb
@@ -392,7 +392,7 @@ RSpec.describe 'including resources alongside normal operations', type: :request
     let(:article_policy_scope) { Article.where(id: article.id) }
 
     subject(:last_response) { get("/articles/#{article.external_id}/articles?include=#{include_query}") }
-    let!(:chained_authorizer) { allow_operation('show_related_resources', source_record: article) }
+    let!(:chained_authorizer) { allow_operation('show_related_resources', source_record: article, related_record_class: article.class) }
 
     include_examples :include_directive_tests
   end

--- a/spec/requests/related_resources_operations_spec.rb
+++ b/spec/requests/related_resources_operations_spec.rb
@@ -24,6 +24,7 @@ RSpec.describe 'Related resources operations', type: :request do
 
     let(:policy_scope) { Article.all }
     let(:comments_on_article) { article.comments }
+    let(:comments_class) { comments_on_article.first.class }
     let(:comments_policy_scope) { comments_on_article.limit(1) }
 
     before do
@@ -31,12 +32,12 @@ RSpec.describe 'Related resources operations', type: :request do
     end
 
     context 'unauthorized for show_related_resources' do
-      before { disallow_operation('show_related_resources', source_record: article) }
+      before { disallow_operation('show_related_resources', source_record: article, related_record_class: comments_class) }
       it { is_expected.to be_forbidden }
     end
 
     context 'authorized for show_related_resources' do
-      before { allow_operation('show_related_resources', source_record: article) }
+      before { allow_operation('show_related_resources', source_record: article, related_record_class: comments_class) }
       it { is_expected.to be_ok }
 
       # If this happens in real life, it's mostly a bug. We want to document the


### PR DESCRIPTION
This PR aims to fix the issue with the related resources policy. As discussed in #111 we would expect when calling `GET /resource/:id/other-resources` that `resource#show?` policy is checked (already the case) but als `other-resources#index?` is checked. This PR implements that behaviour. 

It is my first work with this code base so probably I forgot to add some tests or something like that, I would really like to have some feedback and improve the code.

I am also wondering if this behaviour should be applied to `show_relationship` as well. Since otherwise it is still possible to do `GET /resource/:id/relationships/other-resource` or do I interpret that method wrong? (ref: https://github.com/venuu/jsonapi-authorization/blob/master/lib/jsonapi/authorization/default_pundit_authorizer.rb#L54)

I would like to have some feedback and your ideas about this.


Fixes #111 