### PR TITLE
Downgrade sqlite

### DIFF
--- a/jsonapi-authorization.gemspec
+++ b/jsonapi-authorization.gemspec
@@ -31,5 +31,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "pry-rails"
   spec.add_development_dependency "rubocop", "~> 0.36.0"
   spec.add_development_dependency "phare", "~> 0.7.1"
-  spec.add_development_dependency "sqlite3"
+  spec.add_development_dependency "sqlite3", "~> 1.3.6"
 end


### PR DESCRIPTION
Try to fix travis by downgrading sqlite. It gives an error in travis that SQLite 1.3.6 cannot be actived, but that 1.4.0 is already activated. So I quess that downgrading it to 1.3.6 will fix it.

Travis error:
`can't activate sqlite3 (~> 1.3.6), already activated sqlite3-1.4.0.`

Fixes #114 