### PR TITLE
Check for authorization against related records

### DIFF
--- a/lib/jsonapi/authorization/authorizing_processor.rb
+++ b/lib/jsonapi/authorization/authorizing_processor.rb
@@ -209,15 +209,10 @@ module JSONAPI
 
         relationship_type = params[:relationship_type].to_sym
 
-        related_resources = @resource_klass
-          ._relationship(relationship_type)
-          .resource_klass
-          .find_by_keys(
-            params[:associated_keys],
-            context: context
-          )
-
-        related_records = related_resources.map(&:_model)
+        related_resource_class = @resource_klass._relationship(relationship_type).resource_klass
+        related_records = related_resource_class._model_class.where(
+          related_resource_class._primary_key => params[:associated_keys]
+        )
 
         authorizer.remove_to_many_relationship(
           source_record: source_record,

--- a/lib/jsonapi/authorization/authorizing_processor.rb
+++ b/lib/jsonapi/authorization/authorizing_processor.rb
@@ -329,13 +329,12 @@ module JSONAPI
                 nil
               when Hash # polymorphic relationship
                 resource_class = @resource_klass.resource_for(assoc_value[:type].to_s)
-                resource_class.find_by_key(assoc_value[:id], context: context)._model
-              when Array
-                resource_class = resource_class_for_relationship(assoc_name)
-                resource_class.find_by_keys(assoc_value, context: context).map(&:_model)
+                primary_key = resource_class._primary_key
+                resource_class._model_class.where(primary_key => assoc_value[:id])
               else
                 resource_class = resource_class_for_relationship(assoc_name)
-                resource_class.find_by_key(assoc_value, context: context)._model
+                primary_key = resource_class._primary_key
+                resource_class._model_class.where(primary_key => assoc_value)
               end
 
             {

--- a/lib/jsonapi/authorization/authorizing_processor.rb
+++ b/lib/jsonapi/authorization/authorizing_processor.rb
@@ -298,25 +298,6 @@ module JSONAPI
         resource_class_for_relationship(assoc_name)._model_class
       end
 
-      def related_models
-        data = params[:data]
-        return [] if data.nil?
-
-        [:to_one, :to_many].flat_map do |rel_type|
-          data[rel_type].flat_map do |assoc_name, assoc_value|
-            case assoc_value
-            when Hash # polymorphic relationship
-              resource_class = @resource_klass.resource_for(assoc_value[:type].to_s)
-              resource_class.find_by_key(assoc_value[:id], context: context)._model
-            else
-              resource_class = resource_class_for_relationship(assoc_name)
-              primary_key = resource_class._primary_key
-              resource_class._model_class.where(primary_key => assoc_value)
-            end
-          end
-        end
-      end
-
       def related_models_with_context
         data = params[:data]
         return { relationship: nil, relation_name: nil, records: nil } if data.nil?

--- a/lib/jsonapi/authorization/authorizing_processor.rb
+++ b/lib/jsonapi/authorization/authorizing_processor.rb
@@ -219,7 +219,7 @@ module JSONAPI
 
         related_records = related_resources.map(&:_model)
 
-        if related_records.count != params[:associated_keys].uniq.count
+        if related_records.size != params[:associated_keys].uniq.size
           fail JSONAPI::Exceptions::RecordNotFound, params[:associated_keys]
         end
 

--- a/lib/jsonapi/authorization/authorizing_processor.rb
+++ b/lib/jsonapi/authorization/authorizing_processor.rb
@@ -216,10 +216,11 @@ module JSONAPI
             params[:associated_keys],
             context: context
           )
+
         related_records = related_resources.map(&:_model)
 
         if related_records.count != params[:associated_keys].uniq.count
-          fail JSONAPI::Exceptions::RecordNotFound.new(params[:associated_keys])
+          fail JSONAPI::Exceptions::RecordNotFound, params[:associated_keys]
         end
 
         authorizer.remove_to_many_relationship(
@@ -316,10 +317,11 @@ module JSONAPI
                 resource_class.find_by_key(assoc_value[:id], context: context)._model
               else
                 resource_class = resource_class_for_relationship(assoc_name)
-                resource_class.find_by_keys(assoc_value, context: context).map(&:_model).tap do |scoped_records|
+                resources = resource_class.find_by_keys(assoc_value, context: context)
+                resources.map(&:_model).tap do |scoped_records|
                   related_ids = Array.wrap(assoc_value).uniq
                   if scoped_records.count != related_ids.count
-                    fail JSONAPI::Exceptions::RecordNotFound.new(related_ids)
+                    fail JSONAPI::Exceptions::RecordNotFound, related_ids
                   end
                 end
               end

--- a/spec/requests/included_resources_spec.rb
+++ b/spec/requests/included_resources_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe 'including resources alongside normal operations', type: :request
           expect(json_included.length).to eq(article.comments.count)
           expect(
             json_included.map { |included| included["id"].to_i }
-          ).to eq(article.comments.map(&:id))
+          ).to match_array(article.comments.map(&:id))
         end
       end
     end
@@ -139,7 +139,9 @@ RSpec.describe 'including resources alongside normal operations', type: :request
         it 'includes only comments allowed by policy scope and associated with the article' do
           json_comments = json_included.select { |item| item['type'] == 'comments' }
           expect(json_comments.length).to eq(article.comments.count)
-          expect(json_comments.map { |i| i['id'] }).to eq(article.comments.pluck(:id).map(&:to_s))
+          expect(
+            json_comments.map { |i| i['id'] }
+          ).to match_array(article.comments.pluck(:id).map(&:to_s))
         end
 
         it 'includes the associated author resource' do
@@ -188,7 +190,9 @@ RSpec.describe 'including resources alongside normal operations', type: :request
             it 'includes only resources allowed by policy scope' do
               second_level_items = json_included.select { |item| item['type'] == 'comments' }
               expect(second_level_items.length).to eq(article.author.comments.count)
-              expect(second_level_items.map { |i| i['id'] }).to eq(article.author.comments.pluck(:id).map(&:to_s))
+              expect(
+                second_level_items.map { |i| i['id'] }
+              ).to match_array(article.author.comments.pluck(:id).map(&:to_s))
             end
           end
         end
@@ -259,7 +263,9 @@ RSpec.describe 'including resources alongside normal operations', type: :request
         it 'includes only comments allowed by policy scope and associated with the article' do
           json_comments = json_included.select { |item| item['type'] == 'comments' }
           expect(json_comments.length).to eq(comments_policy_scope.length)
-          expect(json_comments.map { |i| i['id'] }).to eq(comments_policy_scope.pluck(:id).map(&:to_s))
+          expect(
+            json_comments.map { |i| i['id'] }
+          ).to match_array(comments_policy_scope.pluck(:id).map(&:to_s))
         end
 
         it 'includes the associated author resource' do
@@ -290,7 +296,9 @@ RSpec.describe 'including resources alongside normal operations', type: :request
             it 'includes only resources allowed by policy scope' do
               second_level_items = json_included.select { |item| item['type'] == 'comments' }
               expect(second_level_items.length).to eq(comments_policy_scope.length)
-              expect(second_level_items.map { |i| i['id'] }).to eq(comments_policy_scope.pluck(:id).map(&:to_s))
+              expect(
+                second_level_items.map { |i| i['id'] }
+              ).to match_array(comments_policy_scope.pluck(:id).map(&:to_s))
             end
           end
         end

--- a/spec/requests/included_resources_spec.rb
+++ b/spec/requests/included_resources_spec.rb
@@ -11,6 +11,9 @@ RSpec.describe 'including resources alongside normal operations', type: :request
   let(:article_policy_scope) { Article.all }
   let(:user_policy_scope) { User.all }
 
+  # Take the stubbed scope and call merge(policy_scope.scope.all) so that the original
+  # scope's conditions are not lost. Without it, the stub will always return all records
+  # the user has access to regardless of context.
   before do
     allow_any_instance_of(ArticlePolicy::Scope).to receive(:resolve) do |policy_scope|
       article_policy_scope.merge(policy_scope.scope.all)

--- a/spec/requests/included_resources_spec.rb
+++ b/spec/requests/included_resources_spec.rb
@@ -315,7 +315,7 @@ RSpec.describe 'including resources alongside normal operations', type: :request
         {
           relation_type: :to_one,
           relation_name: :author,
-          records: existing_author
+          records: [existing_author]
         },
         {
           relation_type: :to_many,
@@ -325,7 +325,7 @@ RSpec.describe 'including resources alongside normal operations', type: :request
           # down in the other specs.
           #
           # This is fine, because we test resource create relationships with specific matcher
-          records: kind_of(Array)
+          records: kind_of(ActiveRecord::Relation)
         }
       ]
     end

--- a/spec/requests/relationship_operations_spec.rb
+++ b/spec/requests/relationship_operations_spec.rb
@@ -426,7 +426,7 @@ RSpec.describe 'Relationship operations', type: :request do
           disallow_operation('remove_to_many_relationship', source_record: article, related_records: comments_to_remove, relationship_type: :comments)
         end
 
-        it { is_expected.to be_forbidden }
+        it { is_expected.to be_not_found }
       end
 
       # If this happens in real life, it's mostly a bug. We want to document the

--- a/spec/requests/relationship_operations_spec.rb
+++ b/spec/requests/relationship_operations_spec.rb
@@ -423,12 +423,10 @@ RSpec.describe 'Relationship operations', type: :request do
       context 'limited by policy scope on comments' do
         let(:comments_scope) { Comment.none }
         before do
-          allow_operation('remove_to_many_relationship', source_record: article, related_records: [], relationship_type: :comments)
+          disallow_operation('remove_to_many_relationship', source_record: article, related_records: comments_to_remove, relationship_type: :comments)
         end
 
-        # This succeeds because the request isn't actually able to try removing any comments
-        # due to the comments-to-be-removed being an empty array
-        it { is_expected.to be_successful }
+        it { is_expected.to be_forbidden }
       end
 
       # If this happens in real life, it's mostly a bug. We want to document the

--- a/spec/requests/tricky_operations_spec.rb
+++ b/spec/requests/tricky_operations_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe 'Tricky operations', type: :request do
       [{
         relation_name: :article,
         relation_type: :to_one,
-        records: article
+        records: [article]
       }]
     end
 
@@ -57,6 +57,12 @@ RSpec.describe 'Tricky operations', type: :request do
       before { disallow_operation('create_resource', source_class: Comment, related_records_with_context: related_records_with_context) }
 
       it { is_expected.to be_forbidden }
+
+      context 'which is out of scope' do
+        let(:policy_scope) { Article.none }
+
+        it { is_expected.to be_forbidden }
+      end
     end
   end
 
@@ -135,7 +141,7 @@ RSpec.describe 'Tricky operations', type: :request do
       [{
         relation_name: :taggable,
         relation_type: :to_one,
-        records: article
+        records: [article]
       }]
     end
 
@@ -151,6 +157,12 @@ RSpec.describe 'Tricky operations', type: :request do
       before { disallow_operation('create_resource', source_class: Tag, related_records_with_context: related_records_with_context) }
 
       it { is_expected.to be_forbidden }
+
+      context 'which is out of scope' do
+        let(:policy_scope) { Article.none }
+
+        it { is_expected.to be_forbidden }
+      end
     end
   end
 
@@ -203,13 +215,12 @@ RSpec.describe 'Tricky operations', type: :request do
           [{
             relation_name: :comments,
             relation_type: :to_many,
-            # Empty array of records as they were filtered out by the policy scope
-            records: []
+            records: new_comments
           }]
         end
-        before { allow_operation('replace_fields', source_record: article, related_records_with_context: related_records_with_context) }
+        before { disallow_operation('replace_fields', source_record: article, related_records_with_context: related_records_with_context) }
 
-        it { is_expected.to be_successful }
+        it { is_expected.to be_forbidden }
       end
     end
 

--- a/spec/requests/tricky_operations_spec.rb
+++ b/spec/requests/tricky_operations_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe 'Tricky operations', type: :request do
       context 'which is out of scope' do
         let(:policy_scope) { Article.none }
 
-        it { is_expected.to be_forbidden }
+        it { is_expected.to be_not_found }
       end
     end
   end
@@ -141,7 +141,7 @@ RSpec.describe 'Tricky operations', type: :request do
       [{
         relation_name: :taggable,
         relation_type: :to_one,
-        records: [article]
+        records: article
       }]
     end
 
@@ -161,7 +161,7 @@ RSpec.describe 'Tricky operations', type: :request do
       context 'which is out of scope' do
         let(:policy_scope) { Article.none }
 
-        it { is_expected.to be_forbidden }
+        it { is_expected.to be_not_found }
       end
     end
   end
@@ -220,7 +220,7 @@ RSpec.describe 'Tricky operations', type: :request do
         end
         before { disallow_operation('replace_fields', source_record: article, related_records_with_context: related_records_with_context) }
 
-        it { is_expected.to be_forbidden }
+        it { is_expected.to be_not_found }
       end
     end
 


### PR DESCRIPTION
Fixes https://github.com/venuu/jsonapi-authorization/issues/118

This PR fixes a bug where related resources are not checked for authorization if they are not in the user's scope.

Also fixes inconsistencies between the behavior of has-one, has-many, and polymorphic relationships to always return a 404 instead of sometimes returning a 403 when the user should not be able to see that a given record exists.