### PR TITLE
Fix CI again caused by Bundler v2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ gemfile:
   - gemfiles/rails_5_1_pundit_2.gemfile
   - gemfiles/rails_5_2_pundit_2.gemfile
 before_install:
-  - rvm @global do gem uninstall bundler -a -x
   - gem install bundler -v '< 2'
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 language: ruby
+branches:
+  only:
+    - master
 rvm:
   - 2.3
 gemfile:


### PR DESCRIPTION
Seems like the steps done in https://github.com/venuu/jsonapi-authorization/pull/107 are now broken.