### PR TITLE
Clarify versioning and link to changelogs in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Or install it yourself as:
 
 * `v0.6.x` supports JR `v0.7.x`
 * `v0.8.x` supports JR `v0.8.x`
-* `v1.x.x` and `v2.0.x` releases support JR `v0.9.x`
+* Later releases support JR `v0.9.x`
 
 We aim to support the same Ruby and Ruby on Rails versions as `jsonapi-resources` does. If that's not the case, please [open an issue][issues].
 

--- a/README.md
+++ b/README.md
@@ -59,6 +59,14 @@ Or install it yourself as:
 
 We aim to support the same Ruby and Ruby on Rails versions as `jsonapi-resources` does. If that's not the case, please [open an issue][issues].
 
+## Versioning and changelog
+
+`jsonapi-authorization` follows [Semantic Versioning](https://semver.org/). We prefer to make more major version bumps when we do changes that are likely to be backwards incompatible. That holds true even when it's likely the changes would be backwards compatible for a majority of our users.
+
+Given the nature of an authorization library, it is likely that most changes are major version bumps.
+
+Whenever we do changes, we strive to write good changelogs in the [GitHub releases page](https://github.com/venuu/jsonapi-authorization/releases).
+
 ## Usage
 
 First make sure you have a Pundit policy specified for every backing model that your JR resources use.


### PR DESCRIPTION
Also relax the exact numbering on JR 0.9 support.

These changes hopefully clarify how we got quite quickly from [v1.0.0](https://github.com/venuu/jsonapi-authorization/releases/tag/v1.0.0) to [v2.0.0](https://github.com/venuu/jsonapi-authorization/releases/tag/v2.0.0), and how it's likely we'll soon get to v3.0.0 once https://github.com/venuu/jsonapi-authorization/pull/119 is merged.