### PR TITLE
Fix a bug with has-one relationship authorizers

### DIFF
--- a/lib/jsonapi/authorization/authorizing_processor.rb
+++ b/lib/jsonapi/authorization/authorizing_processor.rb
@@ -315,7 +315,7 @@ module JSONAPI
               when Hash # polymorphic relationship
                 resource_class = @resource_klass.resource_for(assoc_value[:type].to_s)
                 resource_class.find_by_key(assoc_value[:id], context: context)._model
-              else
+              when Array
                 resource_class = resource_class_for_relationship(assoc_name)
                 resources = resource_class.find_by_keys(assoc_value, context: context)
                 resources.map(&:_model).tap do |scoped_records|
@@ -324,6 +324,9 @@ module JSONAPI
                     fail JSONAPI::Exceptions::RecordNotFound, related_ids
                   end
                 end
+              else
+                resource_class = resource_class_for_relationship(assoc_name)
+                resource_class.find_by_key(assoc_value, context: context)._model
               end
 
             {

--- a/spec/requests/included_resources_spec.rb
+++ b/spec/requests/included_resources_spec.rb
@@ -447,7 +447,7 @@ RSpec.describe 'including resources alongside normal operations', type: :request
         {
           relation_type: :to_one,
           relation_name: :author,
-          records: [existing_author]
+          records: existing_author
         },
         {
           relation_type: :to_many,

--- a/spec/requests/tricky_operations_spec.rb
+++ b/spec/requests/tricky_operations_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe 'Tricky operations', type: :request do
       [{
         relation_name: :article,
         relation_type: :to_one,
-        records: [article]
+        records: article
       }]
     end
 


### PR DESCRIPTION
Fixes a bug introduced in https://github.com/venuu/jsonapi-authorization/pull/119

Any has-one relationship authorizers e.g. `ArticlePolicy#create_with_author?(author)` are currently breaking since the default authorizer is calling the method with `[author]` instead of `author`.

I was trying to be too clever in that PR simplifying code and didn't realize that there may be code elsewhere that relied on has-one relationships sending related records back as an actual record instead of potentially a single-object array.

I'd like to add a spec to cover this case since there are no (non-stub setup reliant) specs covering this behavior, but am unsure how to structure it. I believe this can go out on its own now, or am happy to take some feedback as to where to add a test for this.

While there was a major version bump to signify breaking changes, this was not an intended breaking change.