### PR TITLE
Enforce no support for JR v0.10.0 yet in gemspec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@
 *.orig
 .ruby-version
 /gemfiles/*.gemfile.lock
+/gemfiles/.bundle/

--- a/Appraisals
+++ b/Appraisals
@@ -1,47 +1,47 @@
 appraise 'rails-4-2 pundit-1' do
   gem 'rails', '4.2.0'
-  gem 'jsonapi-resources', '~> 0.9'
+  gem 'jsonapi-resources', '~> 0.9.0'
   gem 'pundit', '~> 1.0'
 end
 
 appraise 'rails-5-0 pundit-1' do
   gem 'rails', '5.0.0'
-  gem 'jsonapi-resources', '~> 0.9'
+  gem 'jsonapi-resources', '~> 0.9.0'
   gem 'pundit', '~> 1.0'
 end
 
 appraise 'rails-5-1 pundit-1' do
   gem "rails", "5.1.0"
-  gem 'jsonapi-resources', '~> 0.9'
+  gem 'jsonapi-resources', '~> 0.9.0'
   gem 'pundit', '~> 1.0'
 end
 
 appraise 'rails-5-2 pundit-1' do
   gem 'rails', '5.2.0'
-  gem 'jsonapi-resources', '~> 0.9'
+  gem 'jsonapi-resources', '~> 0.9.0'
   gem 'pundit', '~> 1.0'
 end
 
 appraise 'rails-4-2 pundit-2' do
   gem 'rails', '4.2.0'
-  gem 'jsonapi-resources', '~> 0.9'
+  gem 'jsonapi-resources', '~> 0.9.0'
   gem 'pundit', '~> 2.0'
 end
 
 appraise 'rails-5-0 pundit-2' do
   gem 'rails', '5.0.0'
-  gem 'jsonapi-resources', '~> 0.9'
+  gem 'jsonapi-resources', '~> 0.9.0'
   gem 'pundit', '~> 2.0'
 end
 
 appraise 'rails-5-1 pundit-2' do
   gem 'rails', '5.1.0'
-  gem 'jsonapi-resources', '~> 0.9'
+  gem 'jsonapi-resources', '~> 0.9.0'
   gem 'pundit', '~> 2.0'
 end
 
 appraise 'rails-5-2 pundit-2' do
   gem 'rails', '5.2.0'
-  gem 'jsonapi-resources', '~> 0.9'
+  gem 'jsonapi-resources', '~> 0.9.0'
   gem 'pundit', '~> 2.0'
 end

--- a/gemfiles/rails_4_2_pundit_1.gemfile
+++ b/gemfiles/rails_4_2_pundit_1.gemfile
@@ -3,7 +3,7 @@
 source "https://rubygems.org"
 
 gem "rails", "4.2.0"
-gem "jsonapi-resources", "~> 0.9"
+gem "jsonapi-resources", "~> 0.9.0"
 gem "pundit", "~> 1.0"
 
 gemspec path: "../"

--- a/gemfiles/rails_4_2_pundit_2.gemfile
+++ b/gemfiles/rails_4_2_pundit_2.gemfile
@@ -3,7 +3,7 @@
 source "https://rubygems.org"
 
 gem "rails", "4.2.0"
-gem "jsonapi-resources", "~> 0.9"
+gem "jsonapi-resources", "~> 0.9.0"
 gem "pundit", "~> 2.0"
 
 gemspec path: "../"

--- a/gemfiles/rails_5_0_pundit_1.gemfile
+++ b/gemfiles/rails_5_0_pundit_1.gemfile
@@ -3,7 +3,7 @@
 source "https://rubygems.org"
 
 gem "rails", "5.0.0"
-gem "jsonapi-resources", "~> 0.9"
+gem "jsonapi-resources", "~> 0.9.0"
 gem "pundit", "~> 1.0"
 
 gemspec path: "../"

--- a/gemfiles/rails_5_0_pundit_2.gemfile
+++ b/gemfiles/rails_5_0_pundit_2.gemfile
@@ -3,7 +3,7 @@
 source "https://rubygems.org"
 
 gem "rails", "5.0.0"
-gem "jsonapi-resources", "~> 0.9"
+gem "jsonapi-resources", "~> 0.9.0"
 gem "pundit", "~> 2.0"
 
 gemspec path: "../"

--- a/gemfiles/rails_5_1_pundit_1.gemfile
+++ b/gemfiles/rails_5_1_pundit_1.gemfile
@@ -3,7 +3,7 @@
 source "https://rubygems.org"
 
 gem "rails", "5.1.0"
-gem "jsonapi-resources", "~> 0.9"
+gem "jsonapi-resources", "~> 0.9.0"
 gem "pundit", "~> 1.0"
 
 gemspec path: "../"

--- a/gemfiles/rails_5_1_pundit_2.gemfile
+++ b/gemfiles/rails_5_1_pundit_2.gemfile
@@ -3,7 +3,7 @@
 source "https://rubygems.org"
 
 gem "rails", "5.1.0"
-gem "jsonapi-resources", "~> 0.9"
+gem "jsonapi-resources", "~> 0.9.0"
 gem "pundit", "~> 2.0"
 
 gemspec path: "../"

--- a/gemfiles/rails_5_2_pundit_1.gemfile
+++ b/gemfiles/rails_5_2_pundit_1.gemfile
@@ -3,7 +3,7 @@
 source "https://rubygems.org"
 
 gem "rails", "5.2.0"
-gem "jsonapi-resources", "~> 0.9"
+gem "jsonapi-resources", "~> 0.9.0"
 gem "pundit", "~> 1.0"
 
 gemspec path: "../"

--- a/gemfiles/rails_5_2_pundit_2.gemfile
+++ b/gemfiles/rails_5_2_pundit_2.gemfile
@@ -3,7 +3,7 @@
 source "https://rubygems.org"
 
 gem "rails", "5.2.0"
-gem "jsonapi-resources", "~> 0.9"
+gem "jsonapi-resources", "~> 0.9.0"
 gem "pundit", "~> 2.0"
 
 gemspec path: "../"

--- a/jsonapi-authorization.gemspec
+++ b/jsonapi-authorization.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "jsonapi-resources", "~> 0.9"
+  spec.add_dependency "jsonapi-resources", "~> 0.9.0"
   spec.add_dependency "pundit", ">= 1.0.0", "< 3.0.0"
 
   spec.add_development_dependency "appraisal"


### PR DESCRIPTION
The version constraint was too relaxed, as `jsonapi-authorization` does not yet work with JR v0.10.0 — see #64 for more details.