### PR TITLE
Remove implicit block expectation syntax

### DIFF
--- a/spec/jsonapi/authorization/default_pundit_authorizer_spec.rb
+++ b/spec/jsonapi/authorization/default_pundit_authorizer_spec.rb
@@ -11,13 +11,17 @@ RSpec.describe JSONAPI::Authorization::DefaultPunditAuthorizer do
     context 'authorized for update? on related record' do
       before { stub_policy_actions(send(related_record_method), update?: true) }
 
-      it { is_expected.not_to raise_error }
+      it 'does not raise any errors' do
+        expect { subject }.not_to raise_error
+      end
     end
 
     context 'unauthorized for update? on related record' do
       before { stub_policy_actions(send(related_record_method), update?: false) }
 
-      it { is_expected.to raise_error(::Pundit::NotAuthorizedError) }
+      it 'raises a NotAuthorizedError' do
+        expect { subject }.to raise_error(::Pundit::NotAuthorizedError)
+      end
     end
   end
 
@@ -27,7 +31,9 @@ RSpec.describe JSONAPI::Authorization::DefaultPunditAuthorizer do
         send(related_records_method).each { |r| stub_policy_actions(r, update?: true) }
       end
 
-      it { is_expected.not_to raise_error }
+      it 'does not raise any errors' do
+        expect { subject }.not_to raise_error
+      end
     end
 
     context 'unauthorized for update? on any related records' do
@@ -35,49 +41,57 @@ RSpec.describe JSONAPI::Authorization::DefaultPunditAuthorizer do
         stub_policy_actions(send(related_records_method).first, update?: false)
       end
 
-      it { is_expected.to raise_error(::Pundit::NotAuthorizedError) }
+      it 'raises a NotAuthorizedError' do
+        expect { subject }.to raise_error(::Pundit::NotAuthorizedError)
+      end
     end
   end
 
   describe '#find' do
     subject(:method_call) do
-      -> { authorizer.find(source_class: source_record) }
+      authorizer.find(source_class: source_record)
     end
 
     context 'authorized for index? on record' do
       before { allow_action(source_record, 'index?') }
-      it { is_expected.not_to raise_error }
+      it 'does not raise any errors' do
+        expect { subject }.not_to raise_error
+      end
     end
 
     context 'unauthorized for index? on record' do
       before { disallow_action(source_record, 'index?') }
-      it { is_expected.to raise_error(::Pundit::NotAuthorizedError) }
+      it 'raises a NotAuthorizedError' do
+        expect { subject }.to raise_error(::Pundit::NotAuthorizedError)
+      end
     end
   end
 
   describe '#show' do
     subject(:method_call) do
-      -> { authorizer.show(source_record: source_record) }
+      authorizer.show(source_record: source_record)
     end
 
     context 'authorized for show? on record' do
       before { allow_action(source_record, 'show?') }
-      it { is_expected.not_to raise_error }
+      it 'does not raise any errors' do
+        expect { subject }.not_to raise_error
+      end
     end
 
     context 'unauthorized for show? on record' do
       before { disallow_action(source_record, 'show?') }
-      it { is_expected.to raise_error(::Pundit::NotAuthorizedError) }
+      it 'raises a NotAuthorizedError' do
+        expect { subject }.to raise_error(::Pundit::NotAuthorizedError)
+      end
     end
   end
 
   describe '#show_relationship' do
     subject(:method_call) do
-      lambda do
-        authorizer.show_relationship(
-          source_record: source_record, related_record: related_record
-        )
-      end
+      authorizer.show_relationship(
+        source_record: source_record, related_record: related_record
+      )
     end
 
     context 'authorized for show? on source record' do
@@ -88,18 +102,24 @@ RSpec.describe JSONAPI::Authorization::DefaultPunditAuthorizer do
 
         context 'authorized for show on related record' do
           before { allow_action(related_record, 'show?') }
-          it { is_expected.not_to raise_error }
+          it 'does not raise any errors' do
+            expect { subject }.not_to raise_error
+          end
         end
 
         context 'unauthorized for show on related record' do
           before { disallow_action(related_record, 'show?') }
-          it { is_expected.to raise_error(::Pundit::NotAuthorizedError) }
+          it 'raises a NotAuthorizedError' do
+            expect { subject }.to raise_error(::Pundit::NotAuthorizedError)
+          end
         end
       end
 
       context 'related record is nil' do
         let(:related_record) { nil }
-        it { is_expected.not_to raise_error }
+        it 'does not raise any errors' do
+          expect { subject }.not_to raise_error
+        end
       end
     end
 
@@ -111,30 +131,34 @@ RSpec.describe JSONAPI::Authorization::DefaultPunditAuthorizer do
 
         context 'authorized for show on related record' do
           before { allow_action(related_record, 'show?') }
-          it { is_expected.to raise_error(::Pundit::NotAuthorizedError) }
+          it 'raises a NotAuthorizedError' do
+            expect { subject }.to raise_error(::Pundit::NotAuthorizedError)
+          end
         end
 
         context 'unauthorized for show on related record' do
           before { disallow_action(related_record, 'show?') }
-          it { is_expected.to raise_error(::Pundit::NotAuthorizedError) }
+          it 'raises a NotAuthorizedError' do
+            expect { subject }.to raise_error(::Pundit::NotAuthorizedError)
+          end
         end
       end
 
       context 'related record is nil' do
         let(:related_record) { nil }
-        it { is_expected.to raise_error(::Pundit::NotAuthorizedError) }
+        it 'raises a NotAuthorizedError' do
+          expect { subject }.to raise_error(::Pundit::NotAuthorizedError)
+        end
       end
     end
   end
 
   describe '#show_related_resource' do
     subject(:method_call) do
-      lambda do
-        authorizer.show_related_resource(
-          source_record: source_record,
-          related_record: related_record
-        )
-      end
+      authorizer.show_related_resource(
+        source_record: source_record,
+        related_record: related_record
+      )
     end
 
     context 'authorized for show? on source record' do
@@ -145,18 +169,24 @@ RSpec.describe JSONAPI::Authorization::DefaultPunditAuthorizer do
 
         context 'authorized for show on related record' do
           before { allow_action(related_record, 'show?') }
-          it { is_expected.not_to raise_error }
+          it 'does not raise any errors' do
+            expect { subject }.not_to raise_error
+          end
         end
 
         context 'unauthorized for show on related record' do
           before { disallow_action(related_record, 'show?') }
-          it { is_expected.to raise_error(::Pundit::NotAuthorizedError) }
+          it 'raises a NotAuthorizedError' do
+            expect { subject }.to raise_error(::Pundit::NotAuthorizedError)
+          end
         end
       end
 
       context 'related record is nil' do
         let(:related_record) { nil }
-        it { is_expected.not_to raise_error }
+        it 'does not raise any errors' do
+          expect { subject }.not_to raise_error
+        end
       end
     end
 
@@ -168,18 +198,24 @@ RSpec.describe JSONAPI::Authorization::DefaultPunditAuthorizer do
 
         context 'authorized for show on related record' do
           before { allow_action(related_record, 'show?') }
-          it { is_expected.to raise_error(::Pundit::NotAuthorizedError) }
+          it 'raises a NotAuthorizedError' do
+            expect { subject }.to raise_error(::Pundit::NotAuthorizedError)
+          end
         end
 
         context 'unauthorized for show on related record' do
           before { disallow_action(related_record, 'show?') }
-          it { is_expected.to raise_error(::Pundit::NotAuthorizedError) }
+          it 'raises a NotAuthorizedError' do
+            expect { subject }.to raise_error(::Pundit::NotAuthorizedError)
+          end
         end
       end
 
       context 'related record is nil' do
         let(:related_record) { nil }
-        it { is_expected.to raise_error(::Pundit::NotAuthorizedError) }
+        it 'raises a NotAuthorizedError' do
+          expect { subject }.to raise_error(::Pundit::NotAuthorizedError)
+        end
       end
     end
   end
@@ -188,11 +224,8 @@ RSpec.describe JSONAPI::Authorization::DefaultPunditAuthorizer do
     let(:related_record) { Comment.new }
 
     subject(:method_call) do
-      lambda {
-        authorizer.show_related_resources(source_record: source_record,
-                                          related_record_class: related_record
-      )
-      }
+      authorizer.show_related_resources(source_record: source_record,
+                                        related_record_class: related_record)
     end
 
     context 'authorized for show? on source record' do
@@ -200,12 +233,16 @@ RSpec.describe JSONAPI::Authorization::DefaultPunditAuthorizer do
 
       context 'authorized for index? on related record' do
         before { allow_action(related_record, 'index?') }
-        it { is_expected.not_to raise_error }
+        it 'does not raise any errors' do
+          expect { subject }.not_to raise_error
+        end
       end
 
       context 'unauthorized for index? on related record' do
         before { disallow_action(related_record, 'index?') }
-        it { is_expected.to raise_error(::Pundit::NotAuthorizedError) }
+        it 'raises a NotAuthorizedError' do
+          expect { subject }.to raise_error(::Pundit::NotAuthorizedError)
+        end
       end
     end
 
@@ -214,12 +251,16 @@ RSpec.describe JSONAPI::Authorization::DefaultPunditAuthorizer do
 
       context 'authorized for index? on related record' do
         before { allow_action(related_record, 'index?') }
-        it { is_expected.to raise_error(::Pundit::NotAuthorizedError) }
+        it 'raises a NotAuthorizedError' do
+          expect { subject }.to raise_error(::Pundit::NotAuthorizedError)
+        end
       end
 
       context 'unauthorized for index? on related record' do
         before { disallow_action(related_record, 'index?') }
-        it { is_expected.to raise_error(::Pundit::NotAuthorizedError) }
+        it 'raises a NotAuthorizedError' do
+          expect { subject }.to raise_error(::Pundit::NotAuthorizedError)
+        end
       end
     end
   end
@@ -236,32 +277,38 @@ RSpec.describe JSONAPI::Authorization::DefaultPunditAuthorizer do
       end
 
       subject(:method_call) do
-        lambda do
-          authorizer.replace_fields(
-            source_record: source_record,
-            related_records_with_context: related_records_with_context
-          )
-        end
+        authorizer.replace_fields(
+          source_record: source_record,
+          related_records_with_context: related_records_with_context
+        )
       end
 
       context 'authorized for replace_<type>? and authorized for update? on source record' do
         before { stub_policy_actions(source_record, replace_author?: true, update?: true) }
-        it { is_expected.not_to raise_error }
+        it 'does not raise any errors' do
+          expect { subject }.not_to raise_error
+        end
       end
 
       context 'unauthorized for replace_<type>? and authorized for update? on source record' do
         before { stub_policy_actions(source_record, replace_author?: false, update?: true) }
-        it { is_expected.to raise_error(::Pundit::NotAuthorizedError) }
+        it 'raises a NotAuthorizedError' do
+          expect { subject }.to raise_error(::Pundit::NotAuthorizedError)
+        end
       end
 
       context 'authorized for replace_<type>? and unauthorized for update? on source record' do
         before { stub_policy_actions(source_record, replace_author?: true, update?: false) }
-        it { is_expected.to raise_error(::Pundit::NotAuthorizedError) }
+        it 'raises a NotAuthorizedError' do
+          expect { subject }.to raise_error(::Pundit::NotAuthorizedError)
+        end
       end
 
       context 'unauthorized for replace_<type>? and unauthorized for update? on source record' do
         before { stub_policy_actions(source_record, replace_author?: false, update?: false) }
-        it { is_expected.to raise_error(::Pundit::NotAuthorizedError) }
+        it 'raises a NotAuthorizedError' do
+          expect { subject }.to raise_error(::Pundit::NotAuthorizedError)
+        end
       end
 
       context 'where replace_<type>? is undefined' do
@@ -272,7 +319,9 @@ RSpec.describe JSONAPI::Authorization::DefaultPunditAuthorizer do
 
         context 'unauthorized for update? on source record' do
           before { stub_policy_actions(source_record, update?: false) }
-          it { is_expected.to raise_error(::Pundit::NotAuthorizedError) }
+          it 'raises a NotAuthorizedError' do
+            expect { subject }.to raise_error(::Pundit::NotAuthorizedError)
+          end
         end
       end
     end
@@ -287,43 +336,53 @@ RSpec.describe JSONAPI::Authorization::DefaultPunditAuthorizer do
       end
 
       subject(:method_call) do
-        lambda do
-          authorizer.replace_fields(
-            source_record: source_record,
-            related_records_with_context: related_records_with_context
-          )
-        end
+        authorizer.replace_fields(
+          source_record: source_record,
+          related_records_with_context: related_records_with_context
+        )
       end
 
       context 'authorized for remove_<type>? and authorized for update? on source record' do
         before { stub_policy_actions(source_record, remove_author?: true, update?: true) }
-        it { is_expected.not_to raise_error }
+        it 'does not raise any errors' do
+          expect { subject }.not_to raise_error
+        end
       end
 
       context 'unauthorized for remove_<type>? and authorized for update? on source record' do
         before { stub_policy_actions(source_record, remove_author?: false, update?: true) }
-        it { is_expected.to raise_error(::Pundit::NotAuthorizedError) }
+        it 'raises a NotAuthorizedError' do
+          expect { subject }.to raise_error(::Pundit::NotAuthorizedError)
+        end
       end
 
       context 'authorized for remove_<type>? and unauthorized for update? on source record' do
         before { stub_policy_actions(source_record, remove_author?: true, update?: false) }
-        it { is_expected.to raise_error(::Pundit::NotAuthorizedError) }
+        it 'raises a NotAuthorizedError' do
+          expect { subject }.to raise_error(::Pundit::NotAuthorizedError)
+        end
       end
 
       context 'unauthorized for remove_<type>? and unauthorized for update? on source record' do
         before { stub_policy_actions(source_record, remove_author?: false, update?: false) }
-        it { is_expected.to raise_error(::Pundit::NotAuthorizedError) }
+        it 'raises a NotAuthorizedError' do
+          expect { subject }.to raise_error(::Pundit::NotAuthorizedError)
+        end
       end
 
       context 'where remove_<type>? is undefined' do
         context 'authorized for update? on source record' do
           before { stub_policy_actions(source_record, update?: true) }
-          it { is_expected.not_to raise_error }
+          it 'does not raise any errors' do
+            expect { subject }.not_to raise_error
+          end
         end
 
         context 'unauthorized for update? on source record' do
           before { stub_policy_actions(source_record, update?: false) }
-          it { is_expected.to raise_error(::Pundit::NotAuthorizedError) }
+          it 'raises a NotAuthorizedError' do
+            expect { subject }.to raise_error(::Pundit::NotAuthorizedError)
+          end
         end
       end
     end
@@ -339,44 +398,54 @@ RSpec.describe JSONAPI::Authorization::DefaultPunditAuthorizer do
       end
 
       subject(:method_call) do
-        lambda do
-          authorizer.replace_fields(
-            source_record: source_record,
-            related_records_with_context: related_records_with_context
-          )
-        end
+        authorizer.replace_fields(
+          source_record: source_record,
+          related_records_with_context: related_records_with_context
+        )
       end
 
       context 'authorized for update? on source record and related records is empty' do
         before { allow_action(source_record, 'update?') }
         let(:related_records) { [] }
-        it { is_expected.not_to raise_error }
+        it 'does not raise any errors' do
+          expect { subject }.not_to raise_error
+        end
       end
 
       context 'unauthorized for update? on source record  and related records is empty' do
         before { disallow_action(source_record, 'update?') }
         let(:related_records) { [] }
-        it { is_expected.to raise_error(::Pundit::NotAuthorizedError) }
+        it 'raises a NotAuthorizedError' do
+          expect { subject }.to raise_error(::Pundit::NotAuthorizedError)
+        end
       end
 
       context 'authorized for replace_<type>? and authorized for update? on source record' do
         before { stub_policy_actions(source_record, replace_comments?: true, update?: true) }
-        it { is_expected.not_to raise_error }
+        it 'does not raise any errors' do
+          expect { subject }.not_to raise_error
+        end
       end
 
       context 'unauthorized for replace_<type>? and authorized for update? on source record' do
         before { stub_policy_actions(source_record, replace_comments?: false, update?: true) }
-        it { is_expected.to raise_error(::Pundit::NotAuthorizedError) }
+        it 'raises a NotAuthorizedError' do
+          expect { subject }.to raise_error(::Pundit::NotAuthorizedError)
+        end
       end
 
       context 'authorized for replace_<type>? and unauthorized for update? on source record' do
         before { stub_policy_actions(source_record, replace_comments?: true, update?: false) }
-        it { is_expected.to raise_error(::Pundit::NotAuthorizedError) }
+        it 'raises a NotAuthorizedError' do
+          expect { subject }.to raise_error(::Pundit::NotAuthorizedError)
+        end
       end
 
       context 'unauthorized for replace_<type>? and unauthorized for update? on source record' do
         before { stub_policy_actions(source_record, replace_comments?: false, update?: false) }
-        it { is_expected.to raise_error(::Pundit::NotAuthorizedError) }
+        it 'raises a NotAuthorizedError' do
+          expect { subject }.to raise_error(::Pundit::NotAuthorizedError)
+        end
       end
 
       context 'where replace_<type>? is undefined' do
@@ -387,7 +456,9 @@ RSpec.describe JSONAPI::Authorization::DefaultPunditAuthorizer do
 
         context 'unauthorized for update? on source record' do
           before { stub_policy_actions(source_record, update?: false) }
-          it { is_expected.to raise_error(::Pundit::NotAuthorizedError) }
+          it 'raises a NotAuthorizedError' do
+            expect { subject }.to raise_error(::Pundit::NotAuthorizedError)
+          end
         end
       end
     end
@@ -405,32 +476,38 @@ RSpec.describe JSONAPI::Authorization::DefaultPunditAuthorizer do
       end
       let(:source_class) { source_record.class }
       subject(:method_call) do
-        lambda do
-          authorizer.create_resource(
-            source_class: source_class,
-            related_records_with_context: related_records_with_context
-          )
-        end
+        authorizer.create_resource(
+          source_class: source_class,
+          related_records_with_context: related_records_with_context
+        )
       end
 
       context 'authorized for create? and authorized for create_with_<type>? on source class' do
         before { stub_policy_actions(source_class, create_with_author?: true, create?: true) }
-        it { is_expected.not_to raise_error }
+        it 'does not raise any errors' do
+          expect { subject }.not_to raise_error
+        end
       end
 
       context 'authorized for create? and unauthorized for create_with_<type>? on source class' do
         before { stub_policy_actions(source_class, create_with_author?: false, create?: true) }
-        it { is_expected.to raise_error(::Pundit::NotAuthorizedError) }
+        it 'raises a NotAuthorizedError' do
+          expect { subject }.to raise_error(::Pundit::NotAuthorizedError)
+        end
       end
 
       context 'unauthorized for create? and authorized for create_with_<type>? on source class' do
         before { stub_policy_actions(source_class, create_with_author?: true, create?: false) }
-        it { is_expected.to raise_error(::Pundit::NotAuthorizedError) }
+        it 'raises a NotAuthorizedError' do
+          expect { subject }.to raise_error(::Pundit::NotAuthorizedError)
+        end
       end
 
       context 'unauthorized for create? and unauthorized for create_with_<type>? on source class' do
         before { stub_policy_actions(source_class, create_with_author?: false, create?: false) }
-        it { is_expected.to raise_error(::Pundit::NotAuthorizedError) }
+        it 'raises a NotAuthorizedError' do
+          expect { subject }.to raise_error(::Pundit::NotAuthorizedError)
+        end
       end
 
       context 'where create_with_<type>? is undefined' do
@@ -441,7 +518,9 @@ RSpec.describe JSONAPI::Authorization::DefaultPunditAuthorizer do
 
         context 'unauthorized for create? on source class' do
           before { stub_policy_actions(source_class, create?: false) }
-          it { is_expected.to raise_error(::Pundit::NotAuthorizedError) }
+          it 'raises a NotAuthorizedError' do
+            expect { subject }.to raise_error(::Pundit::NotAuthorizedError)
+          end
         end
       end
     end
@@ -457,46 +536,56 @@ RSpec.describe JSONAPI::Authorization::DefaultPunditAuthorizer do
       end
       let(:source_class) { source_record.class }
       subject(:method_call) do
-        lambda do
-          authorizer.create_resource(
-            source_class: source_class,
-            related_records_with_context: related_records_with_context
-          )
-        end
+        authorizer.create_resource(
+          source_class: source_class,
+          related_records_with_context: related_records_with_context
+        )
       end
 
       context 'authorized for create? on source class and related records is empty' do
         before { stub_policy_actions(source_class, create?: true) }
         let(:related_records) { [] }
-        it { is_expected.not_to raise_error }
+        it 'does not raise any errors' do
+          expect { subject }.not_to raise_error
+        end
       end
 
       context 'authorized for create? and authorized for create_with_<type>? on source class' do
         before { stub_policy_actions(source_class, create_with_comments?: true, create?: true) }
-        it { is_expected.not_to raise_error }
+        it 'does not raise any errors' do
+          expect { subject }.not_to raise_error
+        end
       end
 
       context 'authorized for create? and unauthorized for create_with_<type>? on source class' do
         let(:related_records) { [Comment.new(id: 1), Comment.new(id: 2)] }
         before { stub_policy_actions(source_class, create_with_comments?: false, create?: true) }
-        it { is_expected.to raise_error(::Pundit::NotAuthorizedError) }
+        it 'raises a NotAuthorizedError' do
+          expect { subject }.to raise_error(::Pundit::NotAuthorizedError)
+        end
       end
 
       context 'unauthorized for create? on source class and related records is empty' do
         let(:related_records) { [] }
         before { stub_policy_actions(source_class, create?: false) }
-        it { is_expected.to raise_error(::Pundit::NotAuthorizedError) }
+        it 'raises a NotAuthorizedError' do
+          expect { subject }.to raise_error(::Pundit::NotAuthorizedError)
+        end
       end
 
       context 'unauthorized for create? and authorized for create_with_<type>? on source class' do
         before { stub_policy_actions(source_class, create_with_comments?: true, create?: false) }
-        it { is_expected.to raise_error(::Pundit::NotAuthorizedError) }
+        it 'raises a NotAuthorizedError' do
+          expect { subject }.to raise_error(::Pundit::NotAuthorizedError)
+        end
       end
 
       context 'unauthorized for create? and unauthorized for create_with_<type>? on source class' do
         let(:related_records) { [Comment.new(id: 1), Comment.new(id: 2)] }
         before { stub_policy_actions(source_class, create_with_comments?: false, create?: false) }
-        it { is_expected.to raise_error(::Pundit::NotAuthorizedError) }
+        it 'raises a NotAuthorizedError' do
+          expect { subject }.to raise_error(::Pundit::NotAuthorizedError)
+        end
       end
 
       context 'where create_with_<type>? is undefined' do
@@ -507,7 +596,9 @@ RSpec.describe JSONAPI::Authorization::DefaultPunditAuthorizer do
 
         context 'unauthorized for create? on source class' do
           before { stub_policy_actions(source_class, create?: false) }
-          it { is_expected.to raise_error(::Pundit::NotAuthorizedError) }
+          it 'raises a NotAuthorizedError' do
+            expect { subject }.to raise_error(::Pundit::NotAuthorizedError)
+          end
         end
       end
     end
@@ -515,50 +606,60 @@ RSpec.describe JSONAPI::Authorization::DefaultPunditAuthorizer do
 
   describe '#remove_resource' do
     subject(:method_call) do
-      -> { authorizer.remove_resource(source_record: source_record) }
+      authorizer.remove_resource(source_record: source_record)
     end
 
     context 'authorized for destroy? on record' do
       before { allow_action(source_record, 'destroy?') }
-      it { is_expected.not_to raise_error }
+      it 'does not raise any errors' do
+        expect { subject }.not_to raise_error
+      end
     end
 
     context 'unauthorized for destroy? on record' do
       before { disallow_action(source_record, 'destroy?') }
-      it { is_expected.to raise_error(::Pundit::NotAuthorizedError) }
+      it 'raises a NotAuthorizedError' do
+        expect { subject }.to raise_error(::Pundit::NotAuthorizedError)
+      end
     end
   end
 
   describe '#replace_to_one_relationship' do
     let(:related_record) { User.new }
     subject(:method_call) do
-      lambda do
-        authorizer.replace_to_one_relationship(
-          source_record: source_record,
-          new_related_record: related_record,
-          relationship_type: :author
-        )
-      end
+      authorizer.replace_to_one_relationship(
+        source_record: source_record,
+        new_related_record: related_record,
+        relationship_type: :author
+      )
     end
 
     context 'authorized for replace_<type>? and update? on record' do
       before { stub_policy_actions(source_record, replace_author?: true, update?: true) }
-      it { is_expected.not_to raise_error }
+      it 'does not raise any errors' do
+        expect { subject }.not_to raise_error
+      end
     end
 
     context 'unauthorized for replace_<type>? and authorized for update? on record' do
       before { stub_policy_actions(source_record, replace_author?: false, update?: true) }
-      it { is_expected.to raise_error(::Pundit::NotAuthorizedError) }
+      it 'raises a NotAuthorizedError' do
+        expect { subject }.to raise_error(::Pundit::NotAuthorizedError)
+      end
     end
 
     context 'authorized for replace_<type>? and unauthorized for update? on record' do
       before { stub_policy_actions(source_record, replace_author?: true, update?: false) }
-      it { is_expected.not_to raise_error }
+      it 'does not raise any errors' do
+        expect { subject }.not_to raise_error
+      end
     end
 
     context 'unauthorized for replace_<type>? and update? on record' do
       before { stub_policy_actions(source_record, replace_author?: false, update?: false) }
-      it { is_expected.to raise_error(::Pundit::NotAuthorizedError) }
+      it 'raises a NotAuthorizedError' do
+        expect { subject }.to raise_error(::Pundit::NotAuthorizedError)
+      end
     end
 
     context 'where replace_<type>? is undefined' do
@@ -569,7 +670,9 @@ RSpec.describe JSONAPI::Authorization::DefaultPunditAuthorizer do
 
       context 'unauthorized for update? on source record' do
         before { stub_policy_actions(source_record, update?: false) }
-        it { is_expected.to raise_error(::Pundit::NotAuthorizedError) }
+        it 'raises a NotAuthorizedError' do
+          expect { subject }.to raise_error(::Pundit::NotAuthorizedError)
+        end
       end
     end
   end
@@ -577,33 +680,39 @@ RSpec.describe JSONAPI::Authorization::DefaultPunditAuthorizer do
   describe '#create_to_many_relationship' do
     let(:related_records) { Array.new(3) { Comment.new } }
     subject(:method_call) do
-      lambda do
-        authorizer.create_to_many_relationship(
-          source_record: source_record,
-          new_related_records: related_records,
-          relationship_type: :comments
-        )
-      end
+      authorizer.create_to_many_relationship(
+        source_record: source_record,
+        new_related_records: related_records,
+        relationship_type: :comments
+      )
     end
 
     context 'authorized for add_to_<type>? and update? on record' do
       before { stub_policy_actions(source_record, add_to_comments?: true, update?: true) }
-      it { is_expected.not_to raise_error }
+      it 'does not raise any errors' do
+        expect { subject }.not_to raise_error
+      end
     end
 
     context 'unauthorized for add_to_<type>? and authorized for update? on record' do
       before { stub_policy_actions(source_record, add_to_comments?: false, update?: true) }
-      it { is_expected.to raise_error(::Pundit::NotAuthorizedError) }
+      it 'raises a NotAuthorizedError' do
+        expect { subject }.to raise_error(::Pundit::NotAuthorizedError)
+      end
     end
 
     context 'authorized for add_to_<type>? and unauthorized for update? on record' do
       before { stub_policy_actions(source_record, add_to_comments?: true, update?: false) }
-      it { is_expected.not_to raise_error }
+      it 'does not raise any errors' do
+        expect { subject }.not_to raise_error
+      end
     end
 
     context 'unauthorized for add_to_<type>? and update? on record' do
       before { stub_policy_actions(source_record, add_to_comments?: false, update?: false) }
-      it { is_expected.to raise_error(::Pundit::NotAuthorizedError) }
+      it 'raises a NotAuthorizedError' do
+        expect { subject }.to raise_error(::Pundit::NotAuthorizedError)
+      end
     end
 
     context 'where add_to_<type>? not defined' do
@@ -614,7 +723,9 @@ RSpec.describe JSONAPI::Authorization::DefaultPunditAuthorizer do
 
       context 'unauthorized for update? on record' do
         before { stub_policy_actions(source_record, update?: false) }
-        it { is_expected.to raise_error(::Pundit::NotAuthorizedError) }
+        it 'raises a NotAuthorizedError' do
+          expect { subject }.to raise_error(::Pundit::NotAuthorizedError)
+        end
       end
     end
   end
@@ -623,33 +734,39 @@ RSpec.describe JSONAPI::Authorization::DefaultPunditAuthorizer do
     let(:article) { articles(:article_with_comments) }
     let(:new_comments) { Array.new(3) { Comment.new } }
     subject(:method_call) do
-      lambda do
-        authorizer.replace_to_many_relationship(
-          source_record: article,
-          new_related_records: new_comments,
-          relationship_type: :comments
-        )
-      end
+      authorizer.replace_to_many_relationship(
+        source_record: article,
+        new_related_records: new_comments,
+        relationship_type: :comments
+      )
     end
 
     context 'authorized for replace_<type>? and update? on record' do
       before { stub_policy_actions(article, replace_comments?: true, update?: true) }
-      it { is_expected.not_to raise_error }
+      it 'does not raise any errors' do
+        expect { subject }.not_to raise_error
+      end
     end
 
     context 'unauthorized for replace_<type>? and authorized for update? on record' do
       before { stub_policy_actions(article, replace_comments?: false, update?: true) }
-      it { is_expected.to raise_error(::Pundit::NotAuthorizedError) }
+      it 'raises a NotAuthorizedError' do
+        expect { subject }.to raise_error(::Pundit::NotAuthorizedError)
+      end
     end
 
     context 'authorized for replace_<type>? and unauthorized for update? on record' do
       before { stub_policy_actions(article, replace_comments?: true, update?: false) }
-      it { is_expected.not_to raise_error }
+      it 'does not raise any errors' do
+        expect { subject }.not_to raise_error
+      end
     end
 
     context 'unauthorized for replace_<type>? and update? on record' do
       before { stub_policy_actions(article, replace_comments?: false, update?: false) }
-      it { is_expected.to raise_error(::Pundit::NotAuthorizedError) }
+      it 'raises a NotAuthorizedError' do
+        expect { subject }.to raise_error(::Pundit::NotAuthorizedError)
+      end
     end
 
     context 'where replace_<type>? not defined' do
@@ -660,7 +777,9 @@ RSpec.describe JSONAPI::Authorization::DefaultPunditAuthorizer do
 
       context 'unauthorized for update? on record' do
         before { stub_policy_actions(article, update?: false) }
-        it { is_expected.to raise_error(::Pundit::NotAuthorizedError) }
+        it 'raises a NotAuthorizedError' do
+          expect { subject }.to raise_error(::Pundit::NotAuthorizedError)
+        end
       end
     end
   end
@@ -669,33 +788,40 @@ RSpec.describe JSONAPI::Authorization::DefaultPunditAuthorizer do
     let(:article) { articles(:article_with_comments) }
     let(:comments_to_remove) { article.comments.limit(2) }
     subject(:method_call) do
-      lambda do
-        authorizer.remove_to_many_relationship(
-          source_record: article,
-          related_records: comments_to_remove,
-          relationship_type: :comments
-        )
-      end
+      authorizer.remove_to_many_relationship(
+        source_record: article,
+        related_records: comments_to_remove,
+        relationship_type: :comments
+      )
     end
 
     context 'authorized for remove_from_<type>? and article? on article' do
       before { stub_policy_actions(article, remove_from_comments?: true, update?: true) }
-      it { is_expected.not_to raise_error }
+
+      it 'does not raise any errors' do
+        expect { subject }.not_to raise_error
+      end
     end
 
     context 'unauthorized for remove_from_<type>? and authorized for update? on article' do
       before { stub_policy_actions(article, remove_from_comments?: false, update?: true) }
-      it { is_expected.to raise_error(::Pundit::NotAuthorizedError) }
+      it 'raises a NotAuthorizedError' do
+        expect { subject }.to raise_error(::Pundit::NotAuthorizedError)
+      end
     end
 
     context 'authorized for remove_from_<type>? and unauthorized for update? on article' do
       before { stub_policy_actions(article, remove_from_comments?: true, update?: false) }
-      it { is_expected.not_to raise_error }
+      it 'does not raise any errors' do
+        expect { subject }.not_to raise_error
+      end
     end
 
     context 'unauthorized for remove_from_<type>? and update? on article' do
       before { stub_policy_actions(article, remove_from_comments?: false, update?: false) }
-      it { is_expected.to raise_error(::Pundit::NotAuthorizedError) }
+      it 'raises a NotAuthorizedError' do
+        expect { subject }.to raise_error(::Pundit::NotAuthorizedError)
+      end
     end
 
     context 'where remove_from_<type>? not defined' do
@@ -706,49 +832,61 @@ RSpec.describe JSONAPI::Authorization::DefaultPunditAuthorizer do
 
       context 'unauthorized for update? on article' do
         before { stub_policy_actions(article, update?: false) }
-        it { is_expected.to raise_error(::Pundit::NotAuthorizedError) }
+        it 'raises a NotAuthorizedError' do
+          expect { subject }.to raise_error(::Pundit::NotAuthorizedError)
+        end
       end
     end
   end
 
   describe '#remove_to_one_relationship' do
     subject(:method_call) do
-      lambda do
-        authorizer.remove_to_one_relationship(
-          source_record: source_record, relationship_type: :author
-        )
-      end
+      authorizer.remove_to_one_relationship(
+        source_record: source_record, relationship_type: :author
+      )
     end
 
     context 'authorized for remove_<type>? and article? on record' do
       before { stub_policy_actions(source_record, remove_author?: true, update?: true) }
-      it { is_expected.not_to raise_error }
+      it 'does not raise any errors' do
+        expect { subject }.not_to raise_error
+      end
     end
 
     context 'unauthorized for remove_<type>? and authorized for update? on record' do
       before { stub_policy_actions(source_record, remove_author?: false, update?: true) }
-      it { is_expected.to raise_error(::Pundit::NotAuthorizedError) }
+      it 'raises a NotAuthorizedError' do
+        expect { subject }.to raise_error(::Pundit::NotAuthorizedError)
+      end
     end
 
     context 'authorized for remove_<type>? and unauthorized for update? on record' do
       before { stub_policy_actions(source_record, remove_author?: true, update?: false) }
-      it { is_expected.not_to raise_error }
+      it 'does not raise any errors' do
+        expect { subject }.not_to raise_error
+      end
     end
 
     context 'unauthorized for remove_<type>? and update? on record' do
       before { stub_policy_actions(source_record, remove_author?: false, update?: false) }
-      it { is_expected.to raise_error(::Pundit::NotAuthorizedError) }
+      it 'raises a NotAuthorizedError' do
+        expect { subject }.to raise_error(::Pundit::NotAuthorizedError)
+      end
     end
 
     context 'where remove_<type>? not defined' do
       context 'authorized for update? on record' do
         before { stub_policy_actions(source_record, update?: true) }
-        it { is_expected.not_to raise_error }
+        it 'does not raise any errors' do
+          expect { subject }.not_to raise_error
+        end
       end
 
       context 'unauthorized for update? on record' do
         before { stub_policy_actions(source_record, update?: false) }
-        it { is_expected.to raise_error(::Pundit::NotAuthorizedError) }
+        it 'raises a NotAuthorizedError' do
+          expect { subject }.to raise_error(::Pundit::NotAuthorizedError)
+        end
       end
     end
   end
@@ -757,21 +895,23 @@ RSpec.describe JSONAPI::Authorization::DefaultPunditAuthorizer do
     let(:record_class) { Article }
     let(:source_record) { Comment.new }
     subject(:method_call) do
-      lambda do
-        authorizer.include_has_many_resource(
-          source_record: source_record, record_class: record_class
-        )
-      end
+      authorizer.include_has_many_resource(
+        source_record: source_record, record_class: record_class
+      )
     end
 
     context 'authorized for index? on record class' do
       before { allow_action(record_class, 'index?') }
-      it { is_expected.not_to raise_error }
+      it 'does not raise any errors' do
+        expect { subject }.not_to raise_error
+      end
     end
 
     context 'unauthorized for index? on record class' do
       before { disallow_action(record_class, 'index?') }
-      it { is_expected.to raise_error(::Pundit::NotAuthorizedError) }
+      it 'raises a NotAuthorizedError' do
+        expect { subject }.to raise_error(::Pundit::NotAuthorizedError)
+      end
     end
   end
 
@@ -779,22 +919,24 @@ RSpec.describe JSONAPI::Authorization::DefaultPunditAuthorizer do
     let(:related_record) { Article.new }
     let(:source_record) { Comment.new }
     subject(:method_call) do
-      lambda do
-        authorizer.include_has_one_resource(
-          source_record: source_record,
-          related_record: related_record
-        )
-      end
+      authorizer.include_has_one_resource(
+        source_record: source_record,
+        related_record: related_record
+      )
     end
 
     context 'authorized for show? on record' do
       before { allow_action(related_record, 'show?') }
-      it { is_expected.not_to raise_error }
+      it 'does not raise any errors' do
+        expect { subject }.not_to raise_error
+      end
     end
 
     context 'unauthorized for show? on record' do
       before { disallow_action(related_record, 'show?') }
-      it { is_expected.to raise_error(::Pundit::NotAuthorizedError) }
+      it 'raises a NotAuthorizedError' do
+        expect { subject }.to raise_error(::Pundit::NotAuthorizedError)
+      end
     end
   end
 end


### PR DESCRIPTION
While attempting to run specs to investigate compatibility with JR `v0.10.0`, I ran into several failures with the newly released `rspec-expectations` `v3.8.5`

https://github.com/rspec/rspec-expectations/pull/1125 removed the ability to use implicit block expectations