### PR TITLE
WIP Update for jsonapi-resources v0.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,17 +2,28 @@ language: ruby
 branches:
   only:
     - master
-rvm:
-  - 2.3
-gemfile:
-  - gemfiles/rails_4_2_pundit_1.gemfile
-  - gemfiles/rails_5_0_pundit_1.gemfile
-  - gemfiles/rails_5_1_pundit_1.gemfile
-  - gemfiles/rails_5_2_pundit_1.gemfile
-  - gemfiles/rails_4_2_pundit_2.gemfile
-  - gemfiles/rails_5_0_pundit_2.gemfile
-  - gemfiles/rails_5_1_pundit_2.gemfile
-  - gemfiles/rails_5_2_pundit_2.gemfile
+jobs:
+  include:
+  - rvm: 2.3
+    gemfile: gemfiles/rails_4_2_pundit_1.gemfile
+  - rvm: 2.3
+    gemfile: gemfiles/rails_4_2_pundit_2.gemfile
+  - rvm: 2.5
+    gemfile: gemfiles/rails_5_0_pundit_1.gemfile
+  - rvm: 2.5
+    gemfile: gemfiles/rails_5_0_pundit_2.gemfile
+  - rvm: 2.5
+    gemfile: gemfiles/rails_5_1_pundit_1.gemfile
+  - rvm: 2.5
+    gemfile: gemfiles/rails_5_1_pundit_2.gemfile
+  - rvm: 2.5
+    gemfile: gemfiles/rails_5_2_pundit_1.gemfile
+  - rvm: 2.5
+    gemfile: gemfiles/rails_5_2_pundit_2.gemfile
+  - rvm: 2.5
+    gemfile: gemfiles/rails_6_0_pundit_1.gemfile
+  - rvm: 2.5
+    gemfile: gemfiles/rails_6_0_pundit_2.gemfile
 before_install:
   - gem install bundler -v '< 2'
 notifications:

--- a/Appraisals
+++ b/Appraisals
@@ -1,6 +1,7 @@
 appraise 'rails-4-2 pundit-1' do
   gem 'rails', '4.2.0'
-  gem 'jsonapi-resources', '~> 0.9.0'
+  # ToDo: This is only for testing purposes
+  gem 'jsonapi-resources', :git => 'https://github.com/cerebris/jsonapi-resources.git', :branch => 'track_join_options'
   gem 'pundit', '~> 1.0'
   group :development, :test do
     gem 'sqlite3', '~> 1.3.13'
@@ -9,7 +10,8 @@ end
 
 appraise 'rails-5-0 pundit-1' do
   gem 'rails', '5.0.0'
-  gem 'jsonapi-resources', '~> 0.9.0'
+  # ToDo: This is only for testing purposes
+  gem 'jsonapi-resources', :git => 'https://github.com/cerebris/jsonapi-resources.git', :branch => 'track_join_options'
   gem 'pundit', '~> 1.0'
   group :development, :test do
     gem 'sqlite3', '~> 1.3.13'
@@ -18,7 +20,8 @@ end
 
 appraise 'rails-5-1 pundit-1' do
   gem "rails", "5.1.0"
-  gem 'jsonapi-resources', '~> 0.9.0'
+  # ToDo: This is only for testing purposes
+  gem 'jsonapi-resources', :git => 'https://github.com/cerebris/jsonapi-resources.git', :branch => 'track_join_options'
   gem 'pundit', '~> 1.0'
   group :development, :test do
     gem 'sqlite3', '~> 1.3.13'
@@ -27,7 +30,8 @@ end
 
 appraise 'rails-5-2 pundit-1' do
   gem 'rails', '5.2.0'
-  gem 'jsonapi-resources', '~> 0.9.0'
+  # ToDo: This is only for testing purposes
+  gem 'jsonapi-resources', :git => 'https://github.com/cerebris/jsonapi-resources.git', :branch => 'track_join_options'
   gem 'pundit', '~> 1.0'
   group :development, :test do
     gem 'sqlite3', '~> 1.3.13'
@@ -36,7 +40,7 @@ end
 
 appraise 'rails-6-0 pundit-1' do
   gem 'rails', '~> 6.0.0'
-  gem 'jsonapi-resources', '~> 0.9.0'
+  gem 'jsonapi-resources', :git => 'https://github.com/cerebris/jsonapi-resources.git', :branch => 'track_join_options'
   gem 'pundit', '~> 1.0'
   group :development, :test do
     gem 'sqlite3', '~> 1.4.1'
@@ -45,7 +49,8 @@ end
 
 appraise 'rails-4-2 pundit-2' do
   gem 'rails', '4.2.0'
-  gem 'jsonapi-resources', '~> 0.9.0'
+  # ToDo: This is only for testing purposes
+  gem 'jsonapi-resources', :git => 'https://github.com/cerebris/jsonapi-resources.git', :branch => 'track_join_options'
   gem 'pundit', '~> 2.0'
   group :development, :test do
     gem 'sqlite3', '~> 1.3.13'
@@ -54,7 +59,8 @@ end
 
 appraise 'rails-5-0 pundit-2' do
   gem 'rails', '5.0.0'
-  gem 'jsonapi-resources', '~> 0.9.0'
+  # ToDo: This is only for testing purposes
+  gem 'jsonapi-resources', :git => 'https://github.com/cerebris/jsonapi-resources.git', :branch => 'track_join_options'
   gem 'pundit', '~> 2.0'
   group :development, :test do
     gem 'sqlite3', '~> 1.3.13'
@@ -63,7 +69,8 @@ end
 
 appraise 'rails-5-1 pundit-2' do
   gem 'rails', '5.1.0'
-  gem 'jsonapi-resources', '~> 0.9.0'
+  # ToDo: This is only for testing purposes
+  gem 'jsonapi-resources', :git => 'https://github.com/cerebris/jsonapi-resources.git', :branch => 'track_join_options'
   gem 'pundit', '~> 2.0'
   group :development, :test do
     gem 'sqlite3', '~> 1.3.13'
@@ -72,7 +79,8 @@ end
 
 appraise 'rails-5-2 pundit-2' do
   gem 'rails', '5.2.0'
-  gem 'jsonapi-resources', '~> 0.9.0'
+  # ToDo: This is only for testing purposes
+  gem 'jsonapi-resources', :git => 'https://github.com/cerebris/jsonapi-resources.git', :branch => 'track_join_options'
   gem 'pundit', '~> 2.0'
   group :development, :test do
     gem 'sqlite3', '~> 1.3.13'
@@ -81,7 +89,7 @@ end
 
 appraise 'rails-6-0 pundit-2' do
   gem 'rails', '~> 6.0.0'
-  gem 'jsonapi-resources', '~> 0.9.0'
+  gem 'jsonapi-resources', :git => 'https://github.com/cerebris/jsonapi-resources.git', :branch => 'track_join_options'
   gem 'pundit', '~> 2.0'
   group :development, :test do
     gem 'sqlite3', '~> 1.4.1'

--- a/Appraisals
+++ b/Appraisals
@@ -1,7 +1,7 @@
 appraise 'rails-4-2 pundit-1' do
   gem 'rails', '4.2.0'
   # ToDo: This is only for testing purposes
-  gem 'jsonapi-resources', :git => 'https://github.com/cerebris/jsonapi-resources.git', :branch => 'track_join_options'
+  gem 'jsonapi-resources', :git => 'https://github.com/cerebris/jsonapi-resources.git', :branch => 'use_records_for_joined_resources'
   gem 'pundit', '~> 1.0'
   group :development, :test do
     gem 'sqlite3', '~> 1.3.13'
@@ -11,7 +11,7 @@ end
 appraise 'rails-5-0 pundit-1' do
   gem 'rails', '5.0.0'
   # ToDo: This is only for testing purposes
-  gem 'jsonapi-resources', :git => 'https://github.com/cerebris/jsonapi-resources.git', :branch => 'track_join_options'
+  gem 'jsonapi-resources', :git => 'https://github.com/cerebris/jsonapi-resources.git', :branch => 'use_records_for_joined_resources'
   gem 'pundit', '~> 1.0'
   group :development, :test do
     gem 'sqlite3', '~> 1.3.13'
@@ -21,7 +21,7 @@ end
 appraise 'rails-5-1 pundit-1' do
   gem "rails", "5.1.0"
   # ToDo: This is only for testing purposes
-  gem 'jsonapi-resources', :git => 'https://github.com/cerebris/jsonapi-resources.git', :branch => 'track_join_options'
+  gem 'jsonapi-resources', :git => 'https://github.com/cerebris/jsonapi-resources.git', :branch => 'use_records_for_joined_resources'
   gem 'pundit', '~> 1.0'
   group :development, :test do
     gem 'sqlite3', '~> 1.3.13'
@@ -31,7 +31,7 @@ end
 appraise 'rails-5-2 pundit-1' do
   gem 'rails', '5.2.0'
   # ToDo: This is only for testing purposes
-  gem 'jsonapi-resources', :git => 'https://github.com/cerebris/jsonapi-resources.git', :branch => 'track_join_options'
+  gem 'jsonapi-resources', :git => 'https://github.com/cerebris/jsonapi-resources.git', :branch => 'use_records_for_joined_resources'
   gem 'pundit', '~> 1.0'
   group :development, :test do
     gem 'sqlite3', '~> 1.3.13'
@@ -40,7 +40,7 @@ end
 
 appraise 'rails-6-0 pundit-1' do
   gem 'rails', '~> 6.0.0'
-  gem 'jsonapi-resources', :git => 'https://github.com/cerebris/jsonapi-resources.git', :branch => 'track_join_options'
+  gem 'jsonapi-resources', :git => 'https://github.com/cerebris/jsonapi-resources.git', :branch => 'use_records_for_joined_resources'
   gem 'pundit', '~> 1.0'
   group :development, :test do
     gem 'sqlite3', '~> 1.4.1'
@@ -50,7 +50,7 @@ end
 appraise 'rails-4-2 pundit-2' do
   gem 'rails', '4.2.0'
   # ToDo: This is only for testing purposes
-  gem 'jsonapi-resources', :git => 'https://github.com/cerebris/jsonapi-resources.git', :branch => 'track_join_options'
+  gem 'jsonapi-resources', :git => 'https://github.com/cerebris/jsonapi-resources.git', :branch => 'use_records_for_joined_resources'
   gem 'pundit', '~> 2.0'
   group :development, :test do
     gem 'sqlite3', '~> 1.3.13'
@@ -60,7 +60,7 @@ end
 appraise 'rails-5-0 pundit-2' do
   gem 'rails', '5.0.0'
   # ToDo: This is only for testing purposes
-  gem 'jsonapi-resources', :git => 'https://github.com/cerebris/jsonapi-resources.git', :branch => 'track_join_options'
+  gem 'jsonapi-resources', :git => 'https://github.com/cerebris/jsonapi-resources.git', :branch => 'use_records_for_joined_resources'
   gem 'pundit', '~> 2.0'
   group :development, :test do
     gem 'sqlite3', '~> 1.3.13'
@@ -70,7 +70,7 @@ end
 appraise 'rails-5-1 pundit-2' do
   gem 'rails', '5.1.0'
   # ToDo: This is only for testing purposes
-  gem 'jsonapi-resources', :git => 'https://github.com/cerebris/jsonapi-resources.git', :branch => 'track_join_options'
+  gem 'jsonapi-resources', :git => 'https://github.com/cerebris/jsonapi-resources.git', :branch => 'use_records_for_joined_resources'
   gem 'pundit', '~> 2.0'
   group :development, :test do
     gem 'sqlite3', '~> 1.3.13'
@@ -80,7 +80,7 @@ end
 appraise 'rails-5-2 pundit-2' do
   gem 'rails', '5.2.0'
   # ToDo: This is only for testing purposes
-  gem 'jsonapi-resources', :git => 'https://github.com/cerebris/jsonapi-resources.git', :branch => 'track_join_options'
+  gem 'jsonapi-resources', :git => 'https://github.com/cerebris/jsonapi-resources.git', :branch => 'use_records_for_joined_resources'
   gem 'pundit', '~> 2.0'
   group :development, :test do
     gem 'sqlite3', '~> 1.3.13'
@@ -89,7 +89,7 @@ end
 
 appraise 'rails-6-0 pundit-2' do
   gem 'rails', '~> 6.0.0'
-  gem 'jsonapi-resources', :git => 'https://github.com/cerebris/jsonapi-resources.git', :branch => 'track_join_options'
+  gem 'jsonapi-resources', :git => 'https://github.com/cerebris/jsonapi-resources.git', :branch => 'use_records_for_joined_resources'
   gem 'pundit', '~> 2.0'
   group :development, :test do
     gem 'sqlite3', '~> 1.4.1'

--- a/Appraisals
+++ b/Appraisals
@@ -2,46 +2,88 @@ appraise 'rails-4-2 pundit-1' do
   gem 'rails', '4.2.0'
   gem 'jsonapi-resources', '~> 0.9.0'
   gem 'pundit', '~> 1.0'
+  group :development, :test do
+    gem 'sqlite3', '~> 1.3.13'
+  end
 end
 
 appraise 'rails-5-0 pundit-1' do
   gem 'rails', '5.0.0'
   gem 'jsonapi-resources', '~> 0.9.0'
   gem 'pundit', '~> 1.0'
+  group :development, :test do
+    gem 'sqlite3', '~> 1.3.13'
+  end
 end
 
 appraise 'rails-5-1 pundit-1' do
   gem "rails", "5.1.0"
   gem 'jsonapi-resources', '~> 0.9.0'
   gem 'pundit', '~> 1.0'
+  group :development, :test do
+    gem 'sqlite3', '~> 1.3.13'
+  end
 end
 
 appraise 'rails-5-2 pundit-1' do
   gem 'rails', '5.2.0'
   gem 'jsonapi-resources', '~> 0.9.0'
   gem 'pundit', '~> 1.0'
+  group :development, :test do
+    gem 'sqlite3', '~> 1.3.13'
+  end
+end
+
+appraise 'rails-6-0 pundit-1' do
+  gem 'rails', '~> 6.0.0'
+  gem 'jsonapi-resources', '~> 0.9.0'
+  gem 'pundit', '~> 1.0'
+  group :development, :test do
+    gem 'sqlite3', '~> 1.4.1'
+  end
 end
 
 appraise 'rails-4-2 pundit-2' do
   gem 'rails', '4.2.0'
   gem 'jsonapi-resources', '~> 0.9.0'
   gem 'pundit', '~> 2.0'
+  group :development, :test do
+    gem 'sqlite3', '~> 1.3.13'
+  end
 end
 
 appraise 'rails-5-0 pundit-2' do
   gem 'rails', '5.0.0'
   gem 'jsonapi-resources', '~> 0.9.0'
   gem 'pundit', '~> 2.0'
+  group :development, :test do
+    gem 'sqlite3', '~> 1.3.13'
+  end
 end
 
 appraise 'rails-5-1 pundit-2' do
   gem 'rails', '5.1.0'
   gem 'jsonapi-resources', '~> 0.9.0'
   gem 'pundit', '~> 2.0'
+  group :development, :test do
+    gem 'sqlite3', '~> 1.3.13'
+  end
 end
 
 appraise 'rails-5-2 pundit-2' do
   gem 'rails', '5.2.0'
   gem 'jsonapi-resources', '~> 0.9.0'
   gem 'pundit', '~> 2.0'
+  group :development, :test do
+    gem 'sqlite3', '~> 1.3.13'
+  end
+end
+
+appraise 'rails-6-0 pundit-2' do
+  gem 'rails', '~> 6.0.0'
+  gem 'jsonapi-resources', '~> 0.9.0'
+  gem 'pundit', '~> 2.0'
+  group :development, :test do
+    gem 'sqlite3', '~> 1.4.1'
+  end
 end

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,6 @@
 source 'https://rubygems.org'
 
+# ToDo: This is only for testing purposes
+gem 'jsonapi-resources', :git => 'https://github.com/cerebris/jsonapi-resources.git', :branch => 'track_join_options'
+
 gemspec

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,10 @@
 source 'https://rubygems.org'
 
-# ToDo: This is only for testing purposes
-gem 'jsonapi-resources', :git => 'https://github.com/cerebris/jsonapi-resources.git', :branch => 'track_join_options'
+# TODO: This is only for testing purposes
+gem(
+  'jsonapi-resources',
+  git: 'https://github.com/cerebris/jsonapi-resources.git',
+  branch: 'track_join_options'
+)
 
 gemspec

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ source 'https://rubygems.org'
 gem(
   'jsonapi-resources',
   git: 'https://github.com/cerebris/jsonapi-resources.git',
-  branch: 'track_join_options'
+  branch: 'use_records_for_joined_resources'
 )
 
 gemspec

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # JSONAPI::Authorization
 
-[![Build Status](https://img.shields.io/travis/venuu/jsonapi-authorization/master.svg?style=flat&maxAge=3600)](https://travis-ci.org/venuu/jsonapi-authorization) [![Gem Version](https://img.shields.io/gem/v/jsonapi-authorization.svg?style=flat&maxAge=3600)](https://rubygems.org/gems/jsonapi-authorization)
+[![Build Status](https://img.shields.io/travis/com/venuu/jsonapi-authorization/master.svg?style=flat&maxAge=3600)](https://travis-ci.com/venuu/jsonapi-authorization) [![Gem Version](https://img.shields.io/gem/v/jsonapi-authorization.svg?style=flat&maxAge=3600)](https://rubygems.org/gems/jsonapi-authorization)
 
 **NOTE:** This README is the documentation for `JSONAPI::Authorization`. If you are viewing this at the
 [project page on Github](https://github.com/venuu/jsonapi-authorization) you are viewing the documentation for the `master`

--- a/gemfiles/rails_4_2_pundit_1.gemfile
+++ b/gemfiles/rails_4_2_pundit_1.gemfile
@@ -2,8 +2,8 @@
 
 source "https://rubygems.org"
 
+gem "jsonapi-resources", git: "https://github.com/cerebris/jsonapi-resources.git", branch: "track_join_options"
 gem "rails", "4.2.0"
-gem "jsonapi-resources", "~> 0.9.0"
 gem "pundit", "~> 1.0"
 
 group :development, :test do

--- a/gemfiles/rails_4_2_pundit_1.gemfile
+++ b/gemfiles/rails_4_2_pundit_1.gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-gem "jsonapi-resources", git: "https://github.com/cerebris/jsonapi-resources.git", branch: "track_join_options"
+gem "jsonapi-resources", git: "https://github.com/cerebris/jsonapi-resources.git", branch: "use_records_for_joined_resources"
 gem "rails", "4.2.0"
 gem "pundit", "~> 1.0"
 

--- a/gemfiles/rails_4_2_pundit_1.gemfile
+++ b/gemfiles/rails_4_2_pundit_1.gemfile
@@ -6,4 +6,8 @@ gem "rails", "4.2.0"
 gem "jsonapi-resources", "~> 0.9.0"
 gem "pundit", "~> 1.0"
 
+group :development, :test do
+  gem "sqlite3", "~> 1.3.13"
+end
+
 gemspec path: "../"

--- a/gemfiles/rails_4_2_pundit_2.gemfile
+++ b/gemfiles/rails_4_2_pundit_2.gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-gem "jsonapi-resources", git: "https://github.com/cerebris/jsonapi-resources.git", branch: "track_join_options"
+gem "jsonapi-resources", git: "https://github.com/cerebris/jsonapi-resources.git", branch: "use_records_for_joined_resources"
 gem "rails", "4.2.0"
 gem "pundit", "~> 2.0"
 

--- a/gemfiles/rails_4_2_pundit_2.gemfile
+++ b/gemfiles/rails_4_2_pundit_2.gemfile
@@ -2,8 +2,8 @@
 
 source "https://rubygems.org"
 
+gem "jsonapi-resources", git: "https://github.com/cerebris/jsonapi-resources.git", branch: "track_join_options"
 gem "rails", "4.2.0"
-gem "jsonapi-resources", "~> 0.9.0"
 gem "pundit", "~> 2.0"
 
 group :development, :test do

--- a/gemfiles/rails_4_2_pundit_2.gemfile
+++ b/gemfiles/rails_4_2_pundit_2.gemfile
@@ -6,4 +6,8 @@ gem "rails", "4.2.0"
 gem "jsonapi-resources", "~> 0.9.0"
 gem "pundit", "~> 2.0"
 
+group :development, :test do
+  gem "sqlite3", "~> 1.3.13"
+end
+
 gemspec path: "../"

--- a/gemfiles/rails_5_0_pundit_1.gemfile
+++ b/gemfiles/rails_5_0_pundit_1.gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-gem "jsonapi-resources", git: "https://github.com/cerebris/jsonapi-resources.git", branch: "track_join_options"
+gem "jsonapi-resources", git: "https://github.com/cerebris/jsonapi-resources.git", branch: "use_records_for_joined_resources"
 gem "rails", "5.0.0"
 gem "pundit", "~> 1.0"
 

--- a/gemfiles/rails_5_0_pundit_1.gemfile
+++ b/gemfiles/rails_5_0_pundit_1.gemfile
@@ -2,8 +2,8 @@
 
 source "https://rubygems.org"
 
+gem "jsonapi-resources", git: "https://github.com/cerebris/jsonapi-resources.git", branch: "track_join_options"
 gem "rails", "5.0.0"
-gem "jsonapi-resources", "~> 0.9.0"
 gem "pundit", "~> 1.0"
 
 group :development, :test do

--- a/gemfiles/rails_5_0_pundit_1.gemfile
+++ b/gemfiles/rails_5_0_pundit_1.gemfile
@@ -6,4 +6,8 @@ gem "rails", "5.0.0"
 gem "jsonapi-resources", "~> 0.9.0"
 gem "pundit", "~> 1.0"
 
+group :development, :test do
+  gem "sqlite3", "~> 1.3.13"
+end
+
 gemspec path: "../"

--- a/gemfiles/rails_5_0_pundit_2.gemfile
+++ b/gemfiles/rails_5_0_pundit_2.gemfile
@@ -2,8 +2,8 @@
 
 source "https://rubygems.org"
 
+gem "jsonapi-resources", git: "https://github.com/cerebris/jsonapi-resources.git", branch: "track_join_options"
 gem "rails", "5.0.0"
-gem "jsonapi-resources", "~> 0.9.0"
 gem "pundit", "~> 2.0"
 
 group :development, :test do

--- a/gemfiles/rails_5_0_pundit_2.gemfile
+++ b/gemfiles/rails_5_0_pundit_2.gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-gem "jsonapi-resources", git: "https://github.com/cerebris/jsonapi-resources.git", branch: "track_join_options"
+gem "jsonapi-resources", git: "https://github.com/cerebris/jsonapi-resources.git", branch: "use_records_for_joined_resources"
 gem "rails", "5.0.0"
 gem "pundit", "~> 2.0"
 

--- a/gemfiles/rails_5_0_pundit_2.gemfile
+++ b/gemfiles/rails_5_0_pundit_2.gemfile
@@ -6,4 +6,8 @@ gem "rails", "5.0.0"
 gem "jsonapi-resources", "~> 0.9.0"
 gem "pundit", "~> 2.0"
 
+group :development, :test do
+  gem "sqlite3", "~> 1.3.13"
+end
+
 gemspec path: "../"

--- a/gemfiles/rails_5_1_pundit_1.gemfile
+++ b/gemfiles/rails_5_1_pundit_1.gemfile
@@ -2,8 +2,8 @@
 
 source "https://rubygems.org"
 
+gem "jsonapi-resources", git: "https://github.com/cerebris/jsonapi-resources.git", branch: "track_join_options"
 gem "rails", "5.1.0"
-gem "jsonapi-resources", "~> 0.9.0"
 gem "pundit", "~> 1.0"
 
 group :development, :test do

--- a/gemfiles/rails_5_1_pundit_1.gemfile
+++ b/gemfiles/rails_5_1_pundit_1.gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-gem "jsonapi-resources", git: "https://github.com/cerebris/jsonapi-resources.git", branch: "track_join_options"
+gem "jsonapi-resources", git: "https://github.com/cerebris/jsonapi-resources.git", branch: "use_records_for_joined_resources"
 gem "rails", "5.1.0"
 gem "pundit", "~> 1.0"
 

--- a/gemfiles/rails_5_1_pundit_1.gemfile
+++ b/gemfiles/rails_5_1_pundit_1.gemfile
@@ -6,4 +6,8 @@ gem "rails", "5.1.0"
 gem "jsonapi-resources", "~> 0.9.0"
 gem "pundit", "~> 1.0"
 
+group :development, :test do
+  gem "sqlite3", "~> 1.3.13"
+end
+
 gemspec path: "../"

--- a/gemfiles/rails_5_1_pundit_2.gemfile
+++ b/gemfiles/rails_5_1_pundit_2.gemfile
@@ -2,8 +2,8 @@
 
 source "https://rubygems.org"
 
+gem "jsonapi-resources", git: "https://github.com/cerebris/jsonapi-resources.git", branch: "track_join_options"
 gem "rails", "5.1.0"
-gem "jsonapi-resources", "~> 0.9.0"
 gem "pundit", "~> 2.0"
 
 group :development, :test do

--- a/gemfiles/rails_5_1_pundit_2.gemfile
+++ b/gemfiles/rails_5_1_pundit_2.gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-gem "jsonapi-resources", git: "https://github.com/cerebris/jsonapi-resources.git", branch: "track_join_options"
+gem "jsonapi-resources", git: "https://github.com/cerebris/jsonapi-resources.git", branch: "use_records_for_joined_resources"
 gem "rails", "5.1.0"
 gem "pundit", "~> 2.0"
 

--- a/gemfiles/rails_5_1_pundit_2.gemfile
+++ b/gemfiles/rails_5_1_pundit_2.gemfile
@@ -6,4 +6,8 @@ gem "rails", "5.1.0"
 gem "jsonapi-resources", "~> 0.9.0"
 gem "pundit", "~> 2.0"
 
+group :development, :test do
+  gem "sqlite3", "~> 1.3.13"
+end
+
 gemspec path: "../"

--- a/gemfiles/rails_5_2_pundit_1.gemfile
+++ b/gemfiles/rails_5_2_pundit_1.gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-gem "jsonapi-resources", git: "https://github.com/cerebris/jsonapi-resources.git", branch: "track_join_options"
+gem "jsonapi-resources", git: "https://github.com/cerebris/jsonapi-resources.git", branch: "use_records_for_joined_resources"
 gem "rails", "5.2.0"
 gem "pundit", "~> 1.0"
 

--- a/gemfiles/rails_5_2_pundit_1.gemfile
+++ b/gemfiles/rails_5_2_pundit_1.gemfile
@@ -2,8 +2,8 @@
 
 source "https://rubygems.org"
 
+gem "jsonapi-resources", git: "https://github.com/cerebris/jsonapi-resources.git", branch: "track_join_options"
 gem "rails", "5.2.0"
-gem "jsonapi-resources", "~> 0.9.0"
 gem "pundit", "~> 1.0"
 
 group :development, :test do

--- a/gemfiles/rails_5_2_pundit_2.gemfile
+++ b/gemfiles/rails_5_2_pundit_2.gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-gem "jsonapi-resources", git: "https://github.com/cerebris/jsonapi-resources.git", branch: "track_join_options"
+gem "jsonapi-resources", git: "https://github.com/cerebris/jsonapi-resources.git", branch: "use_records_for_joined_resources"
 gem "rails", "5.2.0"
 gem "pundit", "~> 2.0"
 

--- a/gemfiles/rails_5_2_pundit_2.gemfile
+++ b/gemfiles/rails_5_2_pundit_2.gemfile
@@ -2,8 +2,8 @@
 
 source "https://rubygems.org"
 
+gem "jsonapi-resources", git: "https://github.com/cerebris/jsonapi-resources.git", branch: "track_join_options"
 gem "rails", "5.2.0"
-gem "jsonapi-resources", "~> 0.9.0"
 gem "pundit", "~> 2.0"
 
 group :development, :test do

--- a/gemfiles/rails_5_2_pundit_2.gemfile
+++ b/gemfiles/rails_5_2_pundit_2.gemfile
@@ -6,4 +6,8 @@ gem "rails", "5.2.0"
 gem "jsonapi-resources", "~> 0.9.0"
 gem "pundit", "~> 2.0"
 
+group :development, :test do
+  gem "sqlite3", "~> 1.3.13"
+end
+
 gemspec path: "../"

--- a/gemfiles/rails_6_0_pundit_1.gemfile
+++ b/gemfiles/rails_6_0_pundit_1.gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-gem "jsonapi-resources", git: "https://github.com/cerebris/jsonapi-resources.git", branch: "track_join_options"
+gem "jsonapi-resources", git: "https://github.com/cerebris/jsonapi-resources.git", branch: "use_records_for_joined_resources"
 gem "rails", "~> 6.0.0"
 gem "pundit", "~> 1.0"
 

--- a/gemfiles/rails_6_0_pundit_1.gemfile
+++ b/gemfiles/rails_6_0_pundit_1.gemfile
@@ -2,8 +2,8 @@
 
 source "https://rubygems.org"
 
+gem "jsonapi-resources", git: "https://github.com/cerebris/jsonapi-resources.git", branch: "track_join_options"
 gem "rails", "~> 6.0.0"
-gem "jsonapi-resources", "~> 0.9.0"
 gem "pundit", "~> 1.0"
 
 group :development, :test do

--- a/gemfiles/rails_6_0_pundit_1.gemfile
+++ b/gemfiles/rails_6_0_pundit_1.gemfile
@@ -2,12 +2,12 @@
 
 source "https://rubygems.org"
 
-gem "rails", "5.2.0"
+gem "rails", "~> 6.0.0"
 gem "jsonapi-resources", "~> 0.9.0"
 gem "pundit", "~> 1.0"
 
 group :development, :test do
-  gem "sqlite3", "~> 1.3.13"
+  gem "sqlite3", "~> 1.4.1"
 end
 
 gemspec path: "../"

--- a/gemfiles/rails_6_0_pundit_2.gemfile
+++ b/gemfiles/rails_6_0_pundit_2.gemfile
@@ -2,8 +2,8 @@
 
 source "https://rubygems.org"
 
+gem "jsonapi-resources", git: "https://github.com/cerebris/jsonapi-resources.git", branch: "track_join_options"
 gem "rails", "~> 6.0.0"
-gem "jsonapi-resources", "~> 0.9.0"
 gem "pundit", "~> 2.0"
 
 group :development, :test do

--- a/gemfiles/rails_6_0_pundit_2.gemfile
+++ b/gemfiles/rails_6_0_pundit_2.gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-gem "jsonapi-resources", git: "https://github.com/cerebris/jsonapi-resources.git", branch: "track_join_options"
+gem "jsonapi-resources", git: "https://github.com/cerebris/jsonapi-resources.git", branch: "use_records_for_joined_resources"
 gem "rails", "~> 6.0.0"
 gem "pundit", "~> 2.0"
 

--- a/gemfiles/rails_6_0_pundit_2.gemfile
+++ b/gemfiles/rails_6_0_pundit_2.gemfile
@@ -2,12 +2,12 @@
 
 source "https://rubygems.org"
 
-gem "rails", "5.2.0"
+gem "rails", "~> 6.0.0"
 gem "jsonapi-resources", "~> 0.9.0"
-gem "pundit", "~> 1.0"
+gem "pundit", "~> 2.0"
 
 group :development, :test do
-  gem "sqlite3", "~> 1.3.13"
+  gem "sqlite3", "~> 1.4.1"
 end
 
 gemspec path: "../"

--- a/jsonapi-authorization.gemspec
+++ b/jsonapi-authorization.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "jsonapi-resources", "~> 0.9.0"
+  spec.add_dependency "jsonapi-resources", "~> 0.10.0"
   spec.add_dependency "pundit", ">= 1.0.0", "< 3.0.0"
 
   spec.add_development_dependency "appraisal"

--- a/jsonapi-authorization.gemspec
+++ b/jsonapi-authorization.gemspec
@@ -31,5 +31,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "pry-rails"
   spec.add_development_dependency "rubocop", "~> 0.36.0"
   spec.add_development_dependency "phare", "~> 0.7.1"
-  spec.add_development_dependency "sqlite3", "~> 1.3.6"
+  spec.add_development_dependency "sqlite3", "~> 1.3"
 end

--- a/lib/jsonapi/authorization/authorizing_processor.rb
+++ b/lib/jsonapi/authorization/authorizing_processor.rb
@@ -91,7 +91,9 @@ module JSONAPI
 
         source_resource = source_klass.find_by_key(source_id, context: context)
 
-        related_resource = resources_from_relationship(source_klass, source_id, relationship_type, context).first
+        related_resource = resources_from_relationship(
+          source_klass, source_id, relationship_type, context
+        ).first
 
         source_record = source_resource._model
         related_record = related_resource._model unless related_resource.nil?
@@ -283,9 +285,11 @@ module JSONAPI
       end
 
       def resources_from_relationship(source_klass, source_id, relationship_type, context)
-        rid = source_klass.find_related_fragments([JSONAPI::ResourceIdentity.new(source_klass, source_id)],
-                                                  relationship_type,
-                                                  context: context).keys.first
+        rid = source_klass.find_related_fragments(
+          [JSONAPI::ResourceIdentity.new(source_klass, source_id)],
+          relationship_type,
+          context: context
+        ).keys.first
 
         rid.resource_klass.find_to_populate_by_keys(rid.id)
       end

--- a/lib/jsonapi/authorization/pundit_scoped_resource.rb
+++ b/lib/jsonapi/authorization/pundit_scoped_resource.rb
@@ -10,18 +10,6 @@ module JSONAPI
           user_context = JSONAPI::Authorization.configuration.user_context(options[:context])
           ::Pundit.policy_scope!(user_context, super)
         end
-
-        def apply_joins(records, join_manager, options)
-          records = super
-          join_manager.join_details.each do |k, v|
-            next if k == '' || v[:join_type] == :root
-            v[:join_options][:relationship_details][:resource_klasses].each_key do |klass|
-              next unless klass.included_modules.include?(PunditScopedResource)
-              records = records.where(v[:alias] => { klass._primary_key => klass.records(options)})
-            end
-          end
-          records
-        end
       end
     end
   end

--- a/spec/dummy/app/controllers/application_controller.rb
+++ b/spec/dummy/app/controllers/application_controller.rb
@@ -1,0 +1,2 @@
+class ApplicationController < ActionController::Base
+end

--- a/spec/dummy/app/controllers/articles_controller.rb
+++ b/spec/dummy/app/controllers/articles_controller.rb
@@ -1,4 +1,4 @@
-class ArticlesController < ActionController::Base
+class ArticlesController < ApplicationController
   include JSONAPI::ActsAsResourceController
   rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
 

--- a/spec/dummy/app/controllers/comments_controller.rb
+++ b/spec/dummy/app/controllers/comments_controller.rb
@@ -1,4 +1,4 @@
-class CommentsController < ActionController::Base
+class CommentsController < ApplicationController
   include JSONAPI::ActsAsResourceController
   rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
 

--- a/spec/dummy/app/controllers/tags_controller.rb
+++ b/spec/dummy/app/controllers/tags_controller.rb
@@ -1,4 +1,4 @@
-class TagsController < ActionController::Base
+class TagsController < ApplicationController
   include JSONAPI::ActsAsResourceController
   rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
 

--- a/spec/dummy/app/controllers/users_controller.rb
+++ b/spec/dummy/app/controllers/users_controller.rb
@@ -1,4 +1,4 @@
-class UsersController < ActionController::Base
+class UsersController < ApplicationController
   include JSONAPI::ActsAsResourceController
   rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
 

--- a/spec/support/custom_matchers.rb
+++ b/spec/support/custom_matchers.rb
@@ -1,0 +1,54 @@
+# Add better debuggability to be_forbidden failures
+RSpec::Matchers.define :be_forbidden do
+  match(&:forbidden?)
+
+  failure_message do |actual|
+    debug_text_for_failure('forbidden', response: actual, last_request: last_request)
+  end
+end
+
+# Add better debuggability to be_not_found failures
+RSpec::Matchers.define :be_not_found do
+  match(&:not_found?)
+
+  failure_message do |actual|
+    debug_text_for_failure('not_found', response: actual, last_request: last_request)
+  end
+end
+
+# Add better debuggability to be_unprocessable failures
+RSpec::Matchers.define :be_unprocessable do
+  match(&:unprocessable?)
+
+  failure_message do |actual|
+    debug_text_for_failure('unprocessable', response: actual, last_request: last_request)
+  end
+end
+
+# Add better debuggability to be_successful failures
+RSpec::Matchers.define :be_successful do
+  match(&:successful?)
+
+  failure_message do |actual|
+    debug_text_for_failure('successful', response: actual, last_request: last_request)
+  end
+end
+
+# Add better debuggability to be_ok failures
+RSpec::Matchers.define :be_ok do
+  match(&:ok?)
+
+  failure_message do |actual|
+    debug_text_for_failure('ok', response: actual, last_request: last_request)
+  end
+end
+
+def debug_text_for_failure(expected, response:, last_request:)
+  debug_text = "expected response to be #{expected} but HTTP code was #{response.status}."
+  debug_text += " Last request was #{last_request.request_method} to #{last_request.fullpath}"
+  unless last_request.get?
+    debug_text += " with body:\n" + last_request.body.read
+  end
+  debug_text += "\nResponse body was:\n" + response.body
+  debug_text
+end


### PR DESCRIPTION
@valscion This is an early stage proof of concept to work with v0.10 and fix #64

Many specs are failing because the changes in the processor are now calling Resource.records, which applies the scopes and raises the `NotImplementedError`. The processor changes are using the new resource replacement for the autogenerated methods that were created in earlier versions.  This might be desirable as the scope is being applied to even the source records, however it's not compatible with the tests.

JR v0.10 replaced the `records_for` method and applies joins against the source resource. Since the ActiveRelation still is based on the Source, even when getting related resources Pundit will detect and use the source's scope. To get around this I'm overriding `apply_joins` and for every `PunditScopedResource` joined in I'm adding a subquery that applies the appropriate scope and filters the result set.

In the `PunditScopedResource` there's a large monkey patch to the JoinManager to add some additional tracking info for the joins. This should go in a future JR version and not added to this gem.
