### PR TITLE
Use Rails < 6 in local development to make tests work

### DIFF
--- a/jsonapi-authorization.gemspec
+++ b/jsonapi-authorization.gemspec
@@ -32,4 +32,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rubocop", "~> 0.36.0"
   spec.add_development_dependency "phare", "~> 0.7.1"
   spec.add_development_dependency "sqlite3", "~> 1.3.6"
+  # Specs don't yet work with Rails 6, so enforce a lower version
+  spec.add_development_dependency "activerecord", "< 6.0.0"
 end


### PR DESCRIPTION
The dummy application used in tests need some love to work with Rails 6, so to get the tests to pass locally, the easiest way is to limit the version of activerecord installed to one before version 6.

To get Rails 6 working, #129 is the way