### PR TITLE
Update build badge to point to travis-ci.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # JSONAPI::Authorization
 
-[![Build Status](https://img.shields.io/travis/venuu/jsonapi-authorization/master.svg?style=flat&maxAge=3600)](https://travis-ci.org/venuu/jsonapi-authorization) [![Gem Version](https://img.shields.io/gem/v/jsonapi-authorization.svg?style=flat&maxAge=3600)](https://rubygems.org/gems/jsonapi-authorization)
+[![Build Status](https://img.shields.io/travis/com/venuu/jsonapi-authorization/master.svg?style=flat&maxAge=3600)](https://travis-ci.com/venuu/jsonapi-authorization) [![Gem Version](https://img.shields.io/gem/v/jsonapi-authorization.svg?style=flat&maxAge=3600)](https://rubygems.org/gems/jsonapi-authorization)
 
 **NOTE:** This README is the documentation for `JSONAPI::Authorization`. If you are viewing this at the
 [project page on Github](https://github.com/venuu/jsonapi-authorization) you are viewing the documentation for the `master`


### PR DESCRIPTION
This repository has been migrated from the old https://travis-ci.org to https://travis-ci.com and is now running with the Travis GitHub application.

Let's see if this brings better status checks to pull requests :relaxed: