### PR TITLE
Add better debuggability to be_X test failures

### DIFF
--- a/spec/support/custom_matchers.rb
+++ b/spec/support/custom_matchers.rb
@@ -1,0 +1,49 @@
+# Add better debuggability to be_forbidden failures
+RSpec::Matchers.define :be_forbidden do
+  match(&:forbidden?)
+
+  failure_message do |actual|
+    "expected response to be forbidden but HTTP code was #{actual.status}." \
+      " Response body was:\n" + actual.body
+  end
+end
+
+# Add better debuggability to be_not_found failures
+RSpec::Matchers.define :be_not_found do
+  match(&:not_found?)
+
+  failure_message do |actual|
+    "expected response to be not_found but HTTP code was #{actual.status}." \
+      " Response body was:\n" + actual.body
+  end
+end
+
+# Add better debuggability to be_unprocessable failures
+RSpec::Matchers.define :be_unprocessable do
+  match(&:unprocessable?)
+
+  failure_message do |actual|
+    "expected response to be unprocessable but HTTP code was #{actual.status}." \
+      " Response body was:\n" + actual.body
+  end
+end
+
+# Add better debuggability to be_successful failures
+RSpec::Matchers.define :be_successful do
+  match(&:successful?)
+
+  failure_message do |actual|
+    "expected response to be successful but HTTP code was #{actual.status}." \
+      " Response body was:\n" + actual.body
+  end
+end
+
+# Add better debuggability to be_ok failures
+RSpec::Matchers.define :be_ok do
+  match(&:ok?)
+
+  failure_message do |actual|
+    "expected response to be ok but HTTP code was #{actual.status}." \
+      " Response body was:\n" + actual.body
+  end
+end

--- a/spec/support/custom_matchers.rb
+++ b/spec/support/custom_matchers.rb
@@ -3,8 +3,7 @@ RSpec::Matchers.define :be_forbidden do
   match(&:forbidden?)
 
   failure_message do |actual|
-    "expected response to be forbidden but HTTP code was #{actual.status}." \
-      " Response body was:\n" + actual.body
+    debug_text_for_failure('forbidden', response: actual, last_request: last_request)
   end
 end
 
@@ -13,8 +12,7 @@ RSpec::Matchers.define :be_not_found do
   match(&:not_found?)
 
   failure_message do |actual|
-    "expected response to be not_found but HTTP code was #{actual.status}." \
-      " Response body was:\n" + actual.body
+    debug_text_for_failure('not_found', response: actual, last_request: last_request)
   end
 end
 
@@ -23,8 +21,7 @@ RSpec::Matchers.define :be_unprocessable do
   match(&:unprocessable?)
 
   failure_message do |actual|
-    "expected response to be unprocessable but HTTP code was #{actual.status}." \
-      " Response body was:\n" + actual.body
+    debug_text_for_failure('unprocessable', response: actual, last_request: last_request)
   end
 end
 
@@ -33,8 +30,7 @@ RSpec::Matchers.define :be_successful do
   match(&:successful?)
 
   failure_message do |actual|
-    "expected response to be successful but HTTP code was #{actual.status}." \
-      " Response body was:\n" + actual.body
+    debug_text_for_failure('successful', response: actual, last_request: last_request)
   end
 end
 
@@ -43,7 +39,16 @@ RSpec::Matchers.define :be_ok do
   match(&:ok?)
 
   failure_message do |actual|
-    "expected response to be ok but HTTP code was #{actual.status}." \
-      " Response body was:\n" + actual.body
+    debug_text_for_failure('ok', response: actual, last_request: last_request)
   end
+end
+
+def debug_text_for_failure(expected, response:, last_request:)
+  debug_text = "expected response to be #{expected} but HTTP code was #{response.status}."
+  debug_text += " Last request was #{last_request.request_method} to #{last_request.fullpath}"
+  unless last_request.get?
+    debug_text += " with body:\n" + last_request.body.read
+  end
+  debug_text += "\nResponse body was:\n" + response.body
+  debug_text
 end


### PR DESCRIPTION
This way test failures will show what the HTTP status code actually was when test fails as well as output the entire response body. The response body will most likely contain vital debugging information to help figure out why the test failed.

This was cherry-picked from a commit I did to https://github.com/venuu/jsonapi-authorization/pull/131 as this will be useful to all the future changes done to this gem.