### PR TITLE
Create Github Action for Tests

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -1,0 +1,33 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+# This workflow will download a prebuilt Ruby version, install dependencies and run tests with Rake
+# For more information see: https://github.com/marketplace/actions/setup-ruby-jruby-and-truffleruby
+
+name: Ruby
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ruby-version: ['2.6', '2.7', '3.0']
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Ruby
+    # To automatically get bug fixes and new Ruby versions for ruby/setup-ruby,
+    # change this to (see https://github.com/ruby/setup-ruby#versioning):
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{ matrix.ruby-version }}
+        bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+    - name: Run tests
+      run: bundle exec rake

--- a/jsonapi-authorization.gemspec
+++ b/jsonapi-authorization.gemspec
@@ -21,8 +21,8 @@ Gem::Specification.new do |spec|
   spec.add_dependency "pundit", ">= 1.0.0", "< 3.0.0"
 
   spec.add_development_dependency "appraisal"
-  spec.add_development_dependency "bundler", "~> 1.11"
-  spec.add_development_dependency "rake", "~> 12.0"
+  spec.add_development_dependency "bundler", "~> 2.2.5"
+  spec.add_development_dependency "rake", "~> 13.0.3"
   spec.add_development_dependency "rspec", "~> 3.8"
   spec.add_development_dependency "rspec-rails", "~> 3.8"
   spec.add_development_dependency "pry"


### PR DESCRIPTION
This will run the tests, but the tests fail which appears to be related to https://github.com/cerebris/jsonapi-resources/issues/1343. Although the reports of the errors are related to rails 6.1 this somehow is reported on these tests. 

```
Failure/Error: require "jsonapi-resources"

NameError:
  uninitialized constant ActionController::ForceSSL